### PR TITLE
package-lambda.sh fix for macos behaviour 

### DIFF
--- a/extras/packaging-scripts/package-lambda.sh
+++ b/extras/packaging-scripts/package-lambda.sh
@@ -56,7 +56,7 @@ if [ "$file_name" != "none" ] && [ "$src_dir" != "none" ]; then
   pip3 install -t $TMP_FOLDER -r $TMP_FOLDER/requirements.txt
 
   # prepare the dist folder
-  mktemp -d "$DIST_FOLDER" # create dist folder, if it doesn't exist
+  [ ! -d "$DIST_FOLDER" ] && mktemp -d "$DIST_FOLDER" # create dist folder, if it doesn't exist
   cd "$DIST_FOLDER" || exit # change directory into dist folder
   rm -f "$file_name" # remove zip file, if exists
 

--- a/extras/packaging-scripts/package-lambda.sh
+++ b/extras/packaging-scripts/package-lambda.sh
@@ -47,7 +47,7 @@ if [ "$file_name" != "none" ] && [ "$src_dir" != "none" ]; then
 
   HERE="${PWD}" # absolute path to this file's folder
   DIST_FOLDER="$HERE/dist" # dist folder for the zip file if bucket is not provided
-  TMP_FOLDER=~/tmp/sra-lambda-src # will be cleaned
+  TMP_FOLDER=~/tmp-sra-lambda-src # will be cleaned
   SRC_FOLDER=$src_dir
 
   # create /lib folder and install python packages


### PR DESCRIPTION
I get an error with the original code that mktemp: mkdtemp fails - I think this is because of the nesting of directories

Initial run with no changes to show the error message

```
./extras/packaging-scripts/package-lambda.sh --file_name test.zip --src_dir solutions/config/aggregator-acct/code/src/
mktemp: mkdtemp failed on /Users/XXX/tmp/sra-lambda-src: No such file or directory
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file ... target_directory
ERROR: Could not open requirements file: [Errno 2] No such file or directory: '/Users/XXX/tmp/sra-lambda-src/requirements.txt'
mktemp: mkdtemp failed on /Users/XXX/Documents/projects/aws-security-reference-architecture-examples/dist: File exists
```

If I create `~/tmp` first with (`mkdir ~/tmp`) then run again things are much better:

```
./extras/packaging-scripts/package-lambda.sh --file_name test.zip --src_dir solutions/config/aggregator-acct/code/src/
/Users/XXX/tmp/sra-lambda-src
Collecting boto3
  Using cached boto3-1.16.24-py2.py3-none-any.whl (129 kB)
Collecting crhelper
  Using cached crhelper-2.0.6-py3-none-any.whl (16 kB)
Collecting s3transfer<0.4.0,>=0.3.0
  Using cached s3transfer-0.3.3-py2.py3-none-any.whl (69 kB)
Collecting jmespath<1.0.0,>=0.7.1
  Using cached jmespath-0.10.0-py2.py3-none-any.whl (24 kB)
Collecting botocore<1.20.0,>=1.19.24
  Using cached botocore-1.19.24-py2.py3-none-any.whl (6.9 MB)
Collecting python-dateutil<3.0.0,>=2.1
  Using cached python_dateutil-2.8.1-py2.py3-none-any.whl (227 kB)
Collecting urllib3<1.27,>=1.25.4; python_version != "3.4"
  Using cached urllib3-1.26.2-py2.py3-none-any.whl (136 kB)
Collecting six>=1.5
  Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
Installing collected packages: jmespath, six, python-dateutil, urllib3, botocore, s3transfer, boto3, crhelper
Successfully installed boto3-1.16.24 botocore-1.19.24 crhelper-2.0.6 jmespath-0.10.0 python-dateutil-2.8.1 s3transfer-0.3.3 six-1.15.0 urllib3-1.26.2
mktemp: mkdtemp failed on /Users/XXX/Documents/projects/aws-security-reference-architecture-examples/dist: File exists
Removing /Users/XXX/tmp/sra-lambda-src
```

But I think this leaves another problem as the script does an `rm -rf $TMP_FOLDER` which would leave `~/tmp`, so it feels cleaner to not nest directories and instead just do:

```
TMP_FOLDER=~/tmp-sra-lambda-src
```

within the script (as opposed to `/tmp/sra-lambda-src`).  This gives a clean run:

```
./extras/packaging-scripts/package-lambda.sh --file_name test.zip --src_dir solutions/config/aggregator-acct/code/src/
/Users/XXX/tmp-sra-lambda-src
Collecting boto3
  Using cached boto3-1.16.24-py2.py3-none-any.whl (129 kB)
Collecting crhelper
  Using cached crhelper-2.0.6-py3-none-any.whl (16 kB)
Collecting s3transfer<0.4.0,>=0.3.0
  Using cached s3transfer-0.3.3-py2.py3-none-any.whl (69 kB)
Collecting botocore<1.20.0,>=1.19.24
  Using cached botocore-1.19.24-py2.py3-none-any.whl (6.9 MB)
Collecting jmespath<1.0.0,>=0.7.1
  Using cached jmespath-0.10.0-py2.py3-none-any.whl (24 kB)
Collecting python-dateutil<3.0.0,>=2.1
  Using cached python_dateutil-2.8.1-py2.py3-none-any.whl (227 kB)
Collecting urllib3<1.27,>=1.25.4; python_version != "3.4"
  Using cached urllib3-1.26.2-py2.py3-none-any.whl (136 kB)
Collecting six>=1.5
  Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
Installing collected packages: six, python-dateutil, urllib3, jmespath, botocore, s3transfer, boto3, crhelper
Successfully installed boto3-1.16.24 botocore-1.19.24 crhelper-2.0.6 jmespath-0.10.0 python-dateutil-2.8.1 s3transfer-0.3.3 six-1.15.0 urllib3-1.26.2
/Users/XXX/Documents/projects/aws-security-reference-architecture-examples/dist
Removing /Users/XXX/tmp-sra-lambda-src
```

What do you think?

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0