### PR TITLE
Fixed issue with enabling S3 protection on the delegated admin account

### DIFF
--- a/solutions/guardduty/guardduty-org/templates/guardduty-org-configuration-role.yaml
+++ b/solutions/guardduty/guardduty-org/templates/guardduty-org-configuration-role.yaml
@@ -100,6 +100,7 @@ Resources:
                   - guardduty:DisassociateMembers
                   - guardduty:ListMembers
                   - guardduty:ListPublishingDestinations
+                  - guardduty:UpdateDetector
                   - guardduty:UpdateOrganizationConfiguration
                   - guardduty:UpdatePublishingDestination
                 Resource:


### PR DESCRIPTION
Changed the Lambda code to add an additional API call to the update_detector API. The update_organization_configuration API did not enable S3 protection for the delegated admin account. 

This fix enables S3 protection on the delegated admin account when the parameter value is true.

Fixes # 7
