### PR TITLE
Changed the deployment order

### DIFF
--- a/solutions/iam/access-analyzer/README.md
+++ b/solutions/iam/access-analyzer/README.md
@@ -143,16 +143,16 @@ AWS Account zone of trust.
 #### Instructions
 
 > **Solution Deployment Order:**
-> 1. Security Account (AccessAnalyzerOrganization)
-> 2. All Accounts (AccessAnalyzerAccount)
+> 1. All Accounts (AccessAnalyzerAccount)
+> 2. Security Account (AccessAnalyzerOrganization)
 
-1. Create CloudFormation StackSets using the following templates
+ Create CloudFormation StackSets using the following templates
    
    |     Account     |   StackSet Name   |  Template  |
    | --------------- | ----------------- | ---------- |
    | Management | CommonRegisterDelegatedAdmin | templates/common-register-delegated-administrator.yaml |
-   | Security | AccessAnalyzerOrganization | templates/access-analyzer-org.yaml |
    | All Accounts | AccessAnalyzerAccount | templates/access-analyzer-acct.yaml |
+   | Security | AccessAnalyzerOrganization | templates/access-analyzer-org.yaml |
    
 ----
 


### PR DESCRIPTION
Changed the deployment order to allow for the service-linked role to get created in the management account before configuring the organization analyzer in the delegated admin account.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0