### PR TITLE
Hotfix/correcting typos

### DIFF
--- a/solutions/common/register-delegated-administrator/aws-control-tower/manifest-v2.yaml
+++ b/solutions/common/register-delegated-administrator/aws-control-tower/manifest-v2.yaml
@@ -9,7 +9,7 @@ resources:
 # Common Register Delegated Administrator Solution
 # -----------------------------------------------------------------------------
   - name: CommonRegisterDelegatedAdmin
-    resource_file: templates/common-register-delegated-admin.yaml
+    resource_file: templates/common-register-delegated-administrator.yaml
     parameters:
       - parameter_key: pDelegatedAdminAccountId
         parameter_value: $[alfred_ssm_/org/member/Audit/account_id]

--- a/solutions/config/conformance-pack-org/README.md
+++ b/solutions/config/conformance-pack-org/README.md
@@ -214,7 +214,7 @@ get started and to evaluate your AWS environment, use one of the sample conforma
 1. Create AWS Config Conformance Pack Templates S3 Bucket in the Security Tooling Account
    * Create an SSM parameter in the Organization Management Account (Optional)
    * CloudFormation template to create the S3 bucket - documentation/setup/create-conformance-pack-templates-bucket.yaml
-2. Upload documentation/setup/conformance-pack-templates/aws-control-tower-detective-guardrails.yaml to the AWS Config 
+2. Upload documentation/setup/conformance-pack-templates/Operational-Best-Practices-for-Encryption-and-Keys.yaml to the AWS Config 
     Conformance Pack Templates S3 Bucket
    
 #### Instructions

--- a/solutions/firewall-manager/firewall-manager-org/README.md
+++ b/solutions/firewall-manager/firewall-manager-org/README.md
@@ -302,8 +302,8 @@ the account when the custom resource is deleted via CloudFormation.
      --src_dir ~/aws-security-reference-architecture-examples/solutions/firewall-manager/firewall-manager-org/code/src
    ```
 
-2. In your Organizational Management Account - deploy the fw-manager-delegated-admin.template. The Template 
-    requires a single parameter: **pDelegatedAdministrationAccountNumber**. Specify the AWS Account Number of the 
+2. In your Organizational Management Account - deploy the fw-manager-delegate-admin.template. The Template 
+    requires a single parameter: **pDelegatedAdminAccountId**. Specify the AWS Account Number of the 
     account that you wish to delegate administration of Firewall Manager to for the parameter. 
     IMPORTANT - replace the parameter values with the Account Number you wish to delegate FW manager administration to, 
     the S3 Bucket you uploaded the Lambda Package to, and the name of the lambda package (s3 key) in that bucket.

--- a/solutions/iam/access-analyzer/aws-control-tower/manifest-v2.yaml
+++ b/solutions/iam/access-analyzer/aws-control-tower/manifest-v2.yaml
@@ -8,26 +8,6 @@ resources:
 # -----------------------------------------------------------------------------
 # IAM Access Analyzer Solution
 # -----------------------------------------------------------------------------
-  - name: AccessAnalyzerOrganization
-    resource_file: templates/access-analyzer-org.yaml
-    parameters:
-      - parameter_key: pAccessAnalyzerName
-        parameter_value: cfct-organization-access-analyzer
-      - parameter_key: pTagKey1
-        parameter_value: cfct
-      - parameter_key: pTagValue1
-        parameter_value: managed-by-cfct
-    deploy_method: stack_set
-    deployment_targets:
-      accounts:
-        - Audit
-    regions:
-      - ap-southeast-2
-      - eu-west-1
-      - us-east-1
-      - us-east-2
-      - us-west-2
-
   - name: AccessAnalyzerAccount
     resource_file: templates/access-analyzer-acct.yaml
     parameters:
@@ -43,6 +23,26 @@ resources:
         - Core
         - management
         - workloads
+    regions:
+      - ap-southeast-2
+      - eu-west-1
+      - us-east-1
+      - us-east-2
+      - us-west-2
+
+  - name: AccessAnalyzerOrganization
+    resource_file: templates/access-analyzer-org.yaml
+    parameters:
+      - parameter_key: pAccessAnalyzerName
+        parameter_value: cfct-organization-access-analyzer
+      - parameter_key: pTagKey1
+        parameter_value: cfct
+      - parameter_key: pTagValue1
+        parameter_value: managed-by-cfct
+    deploy_method: stack_set
+    deployment_targets:
+      accounts:
+        - Audit
     regions:
       - ap-southeast-2
       - eu-west-1

--- a/solutions/macie/macie-org/aws-control-tower/manifest-v2.yaml
+++ b/solutions/macie/macie-org/aws-control-tower/manifest-v2.yaml
@@ -15,7 +15,7 @@ resources:
         parameter_value: "cfct-macie-configuration"
       - parameter_key: pOrgManagementAccountId
         parameter_value: $[alfred_ssm_/org/member/Control-Tower-Management/account_id]
-      - parameter_key: pOrgPrimaryLambdaRoleName
+      - parameter_key: pLambdaRoleName
         parameter_value: "cfct-macie-org-lambda"
       - parameter_key: pTagKey1
         parameter_value: "cfct"


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1], use the [General Contributing Guidance] checklist, 
and follow the pull-request checklist.

[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
[2]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

## Register Delegated Administrator Account
The Resource File name specified in Manifest and the CFn Template name were inconsistent. Fixed template/CFnTemplateName.yaml as correct value.

## Organization Conformance Pack
The ConformancePack file name specified between Readme.md and Manifest was inconsistent. The manifest parameter key "pTemplatePrefix" has been fixed as the correct value.
If you have already provisioned Control Tower, you do not need to deploy aws-control-tower-detective-guardrails.yaml with CfCT.

## Organization Firewall Manager
Align "pDelegatedAdministrationAccountNumber" in README.md with Manifest parameter "pDelegatedAdminAccountId". The manifest parameter key has been fixed as the correct value.

## IAM Access ANalyzer
Change the order of CFn Templates executed by Manifest. If Trust Zone = Organizations of AccessAnalyzer, Service Linked Role “AWSServiceRoleForAccessAnalyzer” is not created automatically. So you need to run the Trust Zone = Account template first. Therefore, Step Functions outputs an error.

## Organization Macie
The Parameter key specified in Manifest "MacieOrgConfigurationRole" was inconsistent with the CFn template.Therefore, an error will occur in the verification of CfCT.


By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0