### PR TITLE
Escape double quotes when setting the usage example text

### DIFF
--- a/extras/packaging-scripts/package-lambda.sh
+++ b/extras/packaging-scripts/package-lambda.sh
@@ -17,7 +17,7 @@
 #           --src_dir ~/Security-Reference-Architecture/solutions/cloudtrail/cloudtrail-org/code/src
 ###########################################################################################
 
-usage="$(basename "$0") [-h] <--file_name s> [--bucket s] <--src_folder s> ---script to package lambda zip and upload to s3
+usage="$(basename \"$0\") [-h] <--file_name s> [--bucket s] <--src_folder s> ---script to package lambda zip and upload to s3
 
 where:
     -h  show this help text


### PR DESCRIPTION
Fixes #63 

Double quotes need to be escaped to set the usage example properly to prevent a syntax error when executing the sh script.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0