### PR TITLE
Bug/s3 block public account access

### DIFF
--- a/aws_sra_examples/solutions/s3/s3_block_account_public_access/README.md
+++ b/aws_sra_examples/solutions/s3/s3_block_account_public_access/README.md
@@ -174,10 +174,11 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 
 #### Solution Delete Instructions <!-- omit in toc -->
 
-1. In the `management account (home region)`, delete the AWS CloudFormation **Stack** created in step 3 of the solution deployment.
+1. In the `management account (home region)`, delete the AWS CloudFormation **Stack** created in step 3 of the solution deployment. **Note:** The solution will not modify the S3 block account public access settings on a `Delete` event. Only the SSM
+   configuration parameter is deleted in this step.
 2. In the `management account (home region)`, delete the AWS CloudFormation **Stack** created in step 2 of the solution deployment.
 3. In the `management account (home region)`, delete the AWS CloudFormation **StackSet** created in step 1 of the solution deployment. **Note:** there should not be any `stack instances` associated with this StackSet.
-4. In the `management account (home region)`, delete the AWS CloudWatch **Log Group** (e.g. /aws/lambda/sra-s3-block-account-public-access) for the Lambda function deployed in step 2 of the solution deployment.
+4. In the `management account (home region)`, delete the AWS CloudWatch **Log Group** (e.g. /aws/lambda/sra-s3-block-account-public-access) for the Lambda function deployed in step 3 of the solution deployment.
 
 ---
 

--- a/aws_sra_examples/solutions/s3/s3_block_account_public_access/customizations_for_aws_control_tower/parameters/sra-s3-block-account-public-access.json
+++ b/aws_sra_examples/solutions/s3/s3_block_account_public_access/customizations_for_aws_control_tower/parameters/sra-s3-block-account-public-access.json
@@ -25,7 +25,7 @@
     },
     {
         "ParameterKey": "pOrganizationId",
-        "ParameterValue": ""
+        "ParameterValue": "$[alfred_ssm_/org/primary/organization_id]"
     },
     {
         "ParameterKey": "pS3BlockAccountPublicAccessLambdaFunctionName",

--- a/aws_sra_examples/solutions/s3/s3_block_account_public_access/templates/sra-s3-block-account-public-access.yaml
+++ b/aws_sra_examples/solutions/s3/s3_block_account_public_access/templates/sra-s3-block-account-public-access.yaml
@@ -199,8 +199,8 @@ Parameters:
     Type: String
 
   pSRASSMParameterPrefix:
-    AllowedValues: ['/sra/sra-s3-block-account-public-access']
-    Default: '/sra/sra-s3-block-account-public-access'
+    AllowedValues: ['/sra/s3-block-account-public-access']
+    Default: '/sra/s3-block-account-public-access'
     Description: SRA SSM parameter prefix to use for storing the configuration properties needed when a new account is created.
     Type: String
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws_sra_examples"
-version = "1.2.0"
+version = "1.2.1"
 description = "AWS Security Reference Architecture Examples"
 authors = ["Amazon Web Services <no_reply@amazon.com>"]
 


### PR DESCRIPTION
- Updated the README to explain what is deleted better
- Removed redundant sra from the SSM parameter path
- Added SSM parameter for the organization id

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0