### PR TITLE
Removed space before toc comment to fix relative links within README …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Change Log <!-- omit in toc -->
+# Change Log<!-- omit in toc -->
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [2021-11-22](#2021-11-22)
@@ -19,33 +19,33 @@ All notable changes to this project will be documented in this file.
 
 ## 2021-11-22
 
-### Added <!-- omit in toc -->
+### Added<!-- omit in toc -->
 
 - EC2 Default EBS Encryption solution
 
-### Changed <!-- omit in toc -->
+### Changed<!-- omit in toc -->
 
 - Nothing Changed
 
 ## 2021-11-20
 
-### Added <!-- omit in toc -->
+### Added<!-- omit in toc -->
 
 - S3 Block Account Public Access solution
 
-### Changed <!-- omit in toc -->
+### Changed<!-- omit in toc -->
 
 - Nothing Changed
 
 ## 2021-11-19
 
-### Added <!-- omit in toc -->
+### Added<!-- omit in toc -->
 
 - Added `.flake8`, `poetry.lock`, `pyproject.toml`, and `.markdownlint.json` to define coding standards that we will require and use when building future solutions. Contributors should use the standards defined within these files before submitting
   pull requests. Existing solutions will get refactored to these standards in future updates.
 - Added S3 `BucketKeyEnabled` to the solutions that create S3 objects (e.g. CloudTrail, GuardDuty, and Macie)
 
-### Changed <!-- omit in toc -->
+### Changed<!-- omit in toc -->
 
 - Removed the AWS Config Aggregator account solution since AWS Control Tower deploys an account aggregator within the Audit account.
 - Modified the directory structure to support multiple internal packages (e.g. 1 for each solution). The folder structure also allows for tests (integration, unit, etc.). See
@@ -58,15 +58,15 @@ All notable changes to this project will be documented in this file.
 
 ## 2021-09-02
 
-### Added <!-- omit in toc -->
+### Added<!-- omit in toc -->
 
 - Nothing Added
 
-### Changed <!-- omit in toc -->
+### Changed<!-- omit in toc -->
 
 - Removed all code and references to AWS Landing Zone as it is currently in Long-term Support and will not receive any additional features.
 
-### Fixed <!-- omit in toc -->
+### Fixed<!-- omit in toc -->
 
 - Nothing Fixed
 
@@ -74,17 +74,17 @@ All notable changes to this project will be documented in this file.
 
 ## 2021-09-01
 
-### Added <!-- omit in toc -->
+### Added<!-- omit in toc -->
 
 - AWS IAM Access Analyzer solution
 - Organization AWS Config Aggregator Solution
 - Common Register Delegated Administrator Solution
 
-### Changed <!-- omit in toc -->
+### Changed<!-- omit in toc -->
 
 - Nothing Changed
 
-### Fixed <!-- omit in toc -->
+### Fixed<!-- omit in toc -->
 
 - Nothing Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing Guidelines <!-- omit in toc -->
+# Contributing Guidelines<!-- omit in toc -->
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [Reporting Bugs/Feature Requests](#reporting-bugsfeature-requests)

--- a/GENERAL-CONTRIBUTING-GUIDANCE.md
+++ b/GENERAL-CONTRIBUTING-GUIDANCE.md
@@ -1,6 +1,6 @@
-# General Guidance for Contributing <!-- omit in toc -->
+# General Guidance for Contributing<!-- omit in toc -->
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [CloudFormation](#cloudformation)
 - [Encryption](#encryption)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# AWS Security Reference Architecture Examples <!-- omit in toc -->
+# AWS Security Reference Architecture Examples<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [Example Solutions](#example-solutions)

--- a/aws_sra_examples/solutions/README.md
+++ b/aws_sra_examples/solutions/README.md
@@ -1,8 +1,8 @@
-# Solutions <!-- omit in toc -->
+# Solutions<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [Solutions Folder layout](#solutions-folder-layout)

--- a/aws_sra_examples/solutions/cloudtrail/cloudtrail_org/README.md
+++ b/aws_sra_examples/solutions/cloudtrail/cloudtrail_org/README.md
@@ -1,8 +1,8 @@
-# Organization CloudTrail <!-- omit in toc -->
+# Organization CloudTrail<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [Deployed Resource Details](#deployed-resource-details)
@@ -25,63 +25,63 @@ what types of events are logged, or otherwise alter the organization trail in an
 
 ![Architecture](./documentation/sra-cloudtrail-org.png)
 
-### 1.0 Organization Management Account <!-- omit in toc -->
+### 1.0 Organization Management Account<!-- omit in toc -->
 
-#### 1.1 AWS CloudFormation <!-- omit in toc -->
+#### 1.1 AWS CloudFormation<!-- omit in toc -->
 
 - All resources are deployed via AWS CloudFormation as a `StackSet` and `Stack Instance` within the management account or a CloudFormation `Stack` within a specific account.
 - The [Customizations for AWS Control Tower](https://aws.amazon.com/solutions/implementations/customizations-for-aws-control-tower/) solution deploys all templates as a CloudFormation `StackSet`.
 - For parameter details, review the [AWS CloudFormation templates](templates/).
 
-#### 1.2 AWS Lambda Function <!-- omit in toc -->
+#### 1.2 AWS Lambda Function<!-- omit in toc -->
 
 - The Lambda Function contains logic for configuring the AWS Organization CloudTrail within the `management account`.
 
-#### 1.3 Lambda Execution IAM Role <!-- omit in toc -->
+#### 1.3 Lambda Execution IAM Role<!-- omit in toc -->
 
 - The AWS Lambda Function Role allows the AWS Lambda service to assume the role and perform actions defined in the attached IAM policies.
 
-#### 1.4 Lambda CloudWatch Log Group <!-- omit in toc -->
+#### 1.4 Lambda CloudWatch Log Group<!-- omit in toc -->
 
 - All the `AWS Lambda Function` logs are sent to a CloudWatch Log Group `</aws/lambda/<LambdaFunctionName>` to help with debugging and traceability of the actions performed.
 - By default the `AWS Lambda Function` will create the CloudWatch Log Group with a `Retention` (14 days) and are encrypted with a CloudWatch Logs service managed encryption key.
 
-#### 1.5 Organization CloudTrail <!-- omit in toc -->
+#### 1.5 Organization CloudTrail<!-- omit in toc -->
 
 - AWS CloudTrail for all AWS Organization accounts
 - Member accounts are automatically added and cannot modify
 - Data events can be disabled via the parameters
 - CloudWatch logs can be disabled via the parameters
 
-#### 1.6 Organization CloudTrail CloudWatch Log Group Role <!-- omit in toc -->
+#### 1.6 Organization CloudTrail CloudWatch Log Group Role<!-- omit in toc -->
 
 - IAM role used to send CloudTrail logs to the CloudWatch log group
 
-#### 1.7 Organization CloudTrail CloudWatch Log Group <!-- omit in toc -->
+#### 1.7 Organization CloudTrail CloudWatch Log Group<!-- omit in toc -->
 
 - Contains the CloudTrail logs with a `Retention` (400 days)
 
 ---
 
-### 2.0 Audit Account <!-- omit in toc -->
+### 2.0 Audit Account<!-- omit in toc -->
 
-#### 2.1 AWS CloudFormation <!-- omit in toc -->
+#### 2.1 AWS CloudFormation<!-- omit in toc -->
 
 - See [1.1 AWS CloudFormation](#11-aws-cloudformation)
 
-#### 2.2 Organization CloudTrail KMS Key <!-- omit in toc -->
+#### 2.2 Organization CloudTrail KMS Key<!-- omit in toc -->
 
 - Customer managed KMS key for the AWS Organizations CloudTrail logs and S3 server-side encryption
 
 ---
 
-### 3.0 Security Log Archive Account <!-- omit in toc -->
+### 3.0 Security Log Archive Account<!-- omit in toc -->
 
-#### 3.1 AWS CloudFormation <!-- omit in toc -->
+#### 3.1 AWS CloudFormation<!-- omit in toc -->
 
 - See [1.1 AWS CloudFormation](#11-aws-cloudformation)
 
-#### 3.2 Organization CloudTrail S3 Bucket <!-- omit in toc -->
+#### 3.2 Organization CloudTrail S3 Bucket<!-- omit in toc -->
 
 - S3 bucket where the Organization CloudTrail logs are sent for all accounts in the AWS Organization
 
@@ -89,12 +89,12 @@ what types of events are logged, or otherwise alter the organization trail in an
 
 ## Implementation Instructions
 
-### Prerequisites <!-- omit in toc -->
+### Prerequisites<!-- omit in toc -->
 
 - AWS Control Tower is deployed.
 - `aws-security-reference-architecture-examples` repository is stored on your local machine or location where you will be deploying from.
 
-### Staging <!-- omit in toc -->
+### Staging<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch the AWS CloudFormation **Stack** using the [prereq-controltower-execution-role.yaml](../../../utils/aws_control_tower/prerequisites/prereq-controltower-execution-role.yaml) template file as the
    source, to implement the `AWSControlTowerExecution` role pre-requisite.
@@ -138,13 +138,13 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 --src_dir "$SRA_REPO"/aws_sra_examples/solutions/cloudtrail/cloudtrail_org/lambda/src
 ```
 
-### Solution Deployment <!-- omit in toc -->
+### Solution Deployment<!-- omit in toc -->
 
-#### Customizations for AWS Control Tower <!-- omit in toc -->
+#### Customizations for AWS Control Tower<!-- omit in toc -->
 
 - [Customizations for AWS Control Tower](./customizations_for_aws_control_tower)
 
-#### AWS CloudFormation <!-- omit in toc -->
+#### AWS CloudFormation<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to the `Audit account (home region)` using the [sra-cloudtrail-kms.yaml](templates/sra-cloudtrail-org-kms.yaml) template file as the source.
 2. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to the `Log Archive account (home region)` using the [sra-cloudtrail-org-bucket.yaml](templates/sra-cloudtrail-org-bucket.yaml) template file as the
@@ -157,13 +157,13 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 > - Update any metric filters and any other resources that reference the CloudWatch Log Group
 > - If a CloudWatch Log Group Subscription is used for forwarding the logs, remove the Subscription from the old group and add it to the new group
 
-#### Verify Solution Deployment <!-- omit in toc -->
+#### Verify Solution Deployment<!-- omit in toc -->
 
 1. Log into the `Management account` and navigate to the CloudTrail page
 2. Select Trails and select the "sra-cloudtrail-org" trail
 3. Verify the correct configurations have been applied
 
-#### Solution Delete Instructions <!-- omit in toc -->
+#### Solution Delete Instructions<!-- omit in toc -->
 
 1. In the `management account (home region)`, delete the AWS CloudFormation **Stack** created in step 3 of the solution deployment.
 2. In the `management account (home region)`, delete the AWS CloudFormation **StackSet** created in step 2 of the solution deployment. **Note:** there should not be any `stack instances` associated with this StackSet.
@@ -174,7 +174,7 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 
 ## Appendix
 
-### CloudFormation StackSet Instructions <!-- omit in toc -->
+### CloudFormation StackSet Instructions<!-- omit in toc -->
 
 If you need to launch an AWS CloudFormation **StackSet** in the `management account`, see below steps (for additional details, see
 [Create a stack set with self-managed permissions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-getting-started-create.html#stacksets-getting-started-create-self-managed))

--- a/aws_sra_examples/solutions/cloudtrail/cloudtrail_org/customizations_for_aws_control_tower/README.md
+++ b/aws_sra_examples/solutions/cloudtrail/cloudtrail_org/customizations_for_aws_control_tower/README.md
@@ -1,10 +1,10 @@
-# Customizations for AWS Control Tower Implementation Instructions <!-- omit in toc -->
+# Customizations for AWS Control Tower Implementation Instructions<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
 ---
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Version 1 Solution Deployment](#version-1-solution-deployment)
 - [Version 2 Solution Deployment](#version-2-solution-deployment)

--- a/aws_sra_examples/solutions/common/common_register_delegated_administrator/README.md
+++ b/aws_sra_examples/solutions/common/common_register_delegated_administrator/README.md
@@ -1,8 +1,8 @@
-# Register Delegated Administrator Account <!-- omit in toc -->
+# Register Delegated Administrator Account<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [Deployed Resource Details](#deployed-resource-details)
@@ -22,35 +22,35 @@ The register delegated administrator account solution is a common solution to re
 
 ![Architecture](./documentation/sra-common-register-delegated-administrator.png)
 
-### 1.0 Organization Management Account <!-- omit in toc -->
+### 1.0 Organization Management Account<!-- omit in toc -->
 
-#### 1.1 AWS CloudFormation <!-- omit in toc -->
+#### 1.1 AWS CloudFormation<!-- omit in toc -->
 
 - All resources are deployed via AWS CloudFormation as a `StackSet` and `Stack Instance` within the management account or a CloudFormation `Stack` within a specific account.
 - The [Customizations for AWS Control Tower](https://aws.amazon.com/solutions/implementations/customizations-for-aws-control-tower/) solution deploys all templates as a CloudFormation `StackSet`.
 - For parameter details, review the [AWS CloudFormation templates](templates/).
 
-#### 1.2 AWS Lambda Function <!-- omit in toc -->
+#### 1.2 AWS Lambda Function<!-- omit in toc -->
 
 - The Lambda function delegates the administrator account for the provided service principals
 
-#### 1.3 Lambda CloudWatch Log Group <!-- omit in toc -->
+#### 1.3 Lambda CloudWatch Log Group<!-- omit in toc -->
 
 - Contains Lambda function execution logs
 
-#### 1.4 Lambda Execution IAM Role <!-- omit in toc -->
+#### 1.4 Lambda Execution IAM Role<!-- omit in toc -->
 
 - IAM role used by the Lambda function to enable AWS service access for the provided service and register an AWS account as the delegated administrator.
 
-#### 1.5 AWS Organizations <!-- omit in toc -->
+#### 1.5 AWS Organizations<!-- omit in toc -->
 
 - AWS Organizations APIs are used to delegate the administrator account
 
 ---
 
-### 2.0 Delegated Administrator Account (Audit) <!-- omit in toc -->
+### 2.0 Delegated Administrator Account (Audit)<!-- omit in toc -->
 
-#### 2.1 Services Supported <!-- omit in toc -->
+#### 2.1 Services Supported<!-- omit in toc -->
 
 - The services that support a delegated administrator account can be configured and managed within this account.
 - Service Principal Mapping
@@ -70,12 +70,12 @@ The register delegated administrator account solution is a common solution to re
 
 ## Implementation Instructions
 
-### Prerequisites <!-- omit in toc -->
+### Prerequisites<!-- omit in toc -->
 
 - AWS Control Tower is deployed.
 - `aws-security-reference-architecture-examples` repository is stored on your local machine or location where you will be deploying from.
 
-### Staging <!-- omit in toc -->
+### Staging<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch the AWS CloudFormation **Stack** using the [prereq-controltower-execution-role.yaml](../../../utils/aws_control_tower/prerequisites/prereq-controltower-execution-role.yaml) source, to implement the
    `AWSControlTowerExecution` role pre-requisite.
@@ -119,17 +119,17 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 --src_dir "$SRA_REPO"/aws_sra_examples/solutions/commmon/common_register_delegated_administrator/lambda/src
 ```
 
-### Solution Deployment <!-- omit in toc -->
+### Solution Deployment<!-- omit in toc -->
 
-#### Customizations for AWS Control Tower <!-- omit in toc -->
+#### Customizations for AWS Control Tower<!-- omit in toc -->
 
 - [Customizations for AWS Control Tower](./customizations_for_aws_control_tower)
 
-#### AWS CloudFormation <!-- omit in toc -->
+#### AWS CloudFormation<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch an AWS CloudFormation **Stack** using the [sra-common-register-delegated-administrator.yaml](templates/sra-common-register-delegated-administrator.yaml) template file as the source.
 
-#### Verify Solution Deployment <!-- omit in toc -->
+#### Verify Solution Deployment<!-- omit in toc -->
 
 - Verify the configuration using the following AWS CLI shell script
 
@@ -141,7 +141,7 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
   --query 'DelegatedServices[*].ServicePrincipal'); done
   ```
 
-#### Solution Delete Instructions <!-- omit in toc -->
+#### Solution Delete Instructions<!-- omit in toc -->
 
 1. In the `management account (home region)`, delete the AWS CloudFormation **Stack** created in step 1 of the solution deployment.
 2. In the `management account (home region)`, delete the AWS CloudWatch **Log Group** (e.g. /aws/lambda/<solution_name>) for the Lambda function deployed in step 3 of the solution deployment.
@@ -150,7 +150,7 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 
 ## Appendix
 
-### CloudFormation StackSet Instructions <!-- omit in toc -->
+### CloudFormation StackSet Instructions<!-- omit in toc -->
 
 If you need to launch an AWS CloudFormation **StackSet** in the `management account`, see below steps (for additional details, see
 [Create a stack set with self-managed permissions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-getting-started-create.html#stacksets-getting-started-create-self-managed))

--- a/aws_sra_examples/solutions/common/common_register_delegated_administrator/customizations_for_aws_control_tower/README.md
+++ b/aws_sra_examples/solutions/common/common_register_delegated_administrator/customizations_for_aws_control_tower/README.md
@@ -1,10 +1,10 @@
-# Customizations for AWS Control Tower Implementation Instructions <!-- omit in toc -->
+# Customizations for AWS Control Tower Implementation Instructions<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
 ---
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Version 1 Solution Deployment](#version-1-solution-deployment)
 - [Version 2 Solution Deployment](#version-2-solution-deployment)

--- a/aws_sra_examples/solutions/config/config_aggregator_org/README.md
+++ b/aws_sra_examples/solutions/config/config_aggregator_org/README.md
@@ -1,8 +1,8 @@
-# AWS Config Aggregator <!-- omit in toc -->
+# AWS Config Aggregator<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [Deployed Resource Details](#deployed-resource-details)
@@ -22,39 +22,39 @@ Aggregator within the delegated administrator account for all the existing and f
 
 ![Architecture](./documentation/config-aggregator-org.png)
 
-### 1.0 Organization Management Account <!-- omit in toc -->
+### 1.0 Organization Management Account<!-- omit in toc -->
 
-#### 1.1 AWS CloudFormation <!-- omit in toc -->
+#### 1.1 AWS CloudFormation<!-- omit in toc -->
 
 - All resources are deployed via AWS CloudFormation as a `StackSet` and `Stack Instance` within the management account or a CloudFormation `Stack` within a specific account.
 - The [Customizations for AWS Control Tower](https://aws.amazon.com/solutions/implementations/customizations-for-aws-control-tower/) solution deploys all templates as a CloudFormation `StackSet`.
 - For parameter details, review the [AWS CloudFormation templates](templates/).
 
-#### 1.2 AWS Organizations <!-- omit in toc -->
+#### 1.2 AWS Organizations<!-- omit in toc -->
 
 - AWS Organizations is used to delegate an administrator account for AWS Config and to identify AWS accounts for aggregation.
 
 ---
 
-### 2.0 Delegated Administrator Account (e.g. Security Tooling, Audit) <!-- omit in toc -->
+### 2.0 Delegated Administrator Account (e.g. Security Tooling, Audit)<!-- omit in toc -->
 
-#### 2.1 AWS CloudFormation <!-- omit in toc -->
+#### 2.1 AWS CloudFormation<!-- omit in toc -->
 
 - See [1.1 AWS CloudFormation](#11-aws-cloudformation)
 
-#### 2.2 AWS Config Aggregator IAM Role <!-- omit in toc -->
+#### 2.2 AWS Config Aggregator IAM Role<!-- omit in toc -->
 
 - IAM role used by AWS Config to access AWS Organizations APIs
 
-#### 2.3 AWS Config Aggregator <!-- omit in toc -->
+#### 2.3 AWS Config Aggregator<!-- omit in toc -->
 
 - AWS Config Aggregator is configured for the AWS Organization and all AWS Regions.
 
 ---
 
-### 3.0 All Existing and Future Organization Member Accounts <!-- omit in toc -->
+### 3.0 All Existing and Future Organization Member Accounts<!-- omit in toc -->
 
-#### 3.1 AWS Config Aggregator <!-- omit in toc -->
+#### 3.1 AWS Config Aggregator<!-- omit in toc -->
 
 - AWS Config Aggregator within each member account has Authorizations for the Delegated Administrator Account to collect AWS Config compliance and configuration data.
 
@@ -62,31 +62,31 @@ Aggregator within the delegated administrator account for all the existing and f
 
 ## Implementation Instructions
 
-### Prerequisites <!-- omit in toc -->
+### Prerequisites<!-- omit in toc -->
 
 - AWS Control Tower is deployed.
 - `aws-security-reference-architecture-examples` repository is stored on your local machine or location where you will be deploying from.
 - Register a `delegated administrator` using the [Common Register Delegated Administrator](../../common/common_register_delegated_administrator) solution
   - pServicePrincipalList = "config.amazonaws.com"
 
-### Solution Deployment <!-- omit in toc -->
+### Solution Deployment<!-- omit in toc -->
 
-#### Customizations for AWS Control Tower <!-- omit in toc -->
+#### Customizations for AWS Control Tower<!-- omit in toc -->
 
 - [Customizations for AWS Control Tower](./customizations_for_aws_control_tower)
 
-#### AWS CloudFormation <!-- omit in toc -->
+#### AWS CloudFormation<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to the `Audit account (home region)` using the [sra-config-aggregator-org-configuration.yaml](templates/sra-config-aggregator-org-configuration.yaml)
    template file as the source.
 
-#### Verify Solution Deployment <!-- omit in toc -->
+#### Verify Solution Deployment<!-- omit in toc -->
 
 - Log into the Audit account and navigate to the AWS Config page
   1. Verify the correct AWS Config Aggregator configurations have been applied
   2. Verify all existing accounts have been enabled (This can take a few minutes to complete)
 
-#### Solution Delete Instructions <!-- omit in toc -->
+#### Solution Delete Instructions<!-- omit in toc -->
 
 1. In the `management account (home region)`, delete the AWS CloudFormation **StackSet** created in step 1 of the solution deployment. **Note:** there should not be any `stack instances` associated with this StackSet.
 2. Clean up the `delegated administrator` registered in the **Prerequisites**

--- a/aws_sra_examples/solutions/config/config_aggregator_org/customizations_for_aws_control_tower/README.md
+++ b/aws_sra_examples/solutions/config/config_aggregator_org/customizations_for_aws_control_tower/README.md
@@ -1,10 +1,10 @@
-# Customizations for AWS Control Tower Implementation Instructions <!-- omit in toc -->
+# Customizations for AWS Control Tower Implementation Instructions<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
 ---
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Version 1 Solution Deployment](#version-1-solution-deployment)
 - [Version 2 Solution Deployment](#version-2-solution-deployment)

--- a/aws_sra_examples/solutions/config/config_conformance_pack_org/README.md
+++ b/aws_sra_examples/solutions/config/config_conformance_pack_org/README.md
@@ -1,8 +1,8 @@
-# Conformance Pack Organization Rules <!-- omit in toc -->
+# Conformance Pack Organization Rules<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [Deployed Resource Details](#deployed-resource-details)
@@ -28,61 +28,61 @@ evaluate your AWS environment, use one of the sample conformance pack templates.
 
 ![Architecture](./documentation/config-conformance-pack-org.png)
 
-### 1.0 Organization Management Account <!-- omit in toc -->
+### 1.0 Organization Management Account<!-- omit in toc -->
 
-#### 1.1 AWS CloudFormation <!-- omit in toc -->
+#### 1.1 AWS CloudFormation<!-- omit in toc -->
 
 - All resources are deployed via AWS CloudFormation as a `StackSet` and `Stack Instance` within the management account or a CloudFormation `Stack` within a specific account.
 - The [Customizations for AWS Control Tower](https://aws.amazon.com/solutions/implementations/customizations-for-aws-control-tower/) solution deploys all templates as a CloudFormation `StackSet`.
 - For parameter details, review the [AWS CloudFormation templates](templates/).
 
-#### 1.2 AWS Organizations <!-- omit in toc -->
+#### 1.2 AWS Organizations<!-- omit in toc -->
 
 - AWS Organizations is used to delegate an administrator account for AWS Config and to identify AWS accounts for aggregation.
 
 ---
 
-### 2.0 Security Log Archive Account <!-- omit in toc -->
+### 2.0 Security Log Archive Account<!-- omit in toc -->
 
-#### 2.1 AWS CloudFormation <!-- omit in toc -->
+#### 2.1 AWS CloudFormation<!-- omit in toc -->
 
 - See [1.1 AWS CloudFormation](#11-aws-cloudformation)
 
-#### 2.2 Conformance Pack Delivery Bucket <!-- omit in toc -->
+#### 2.2 Conformance Pack Delivery Bucket<!-- omit in toc -->
 
 - Organization Conformance Packs require a delivery S3 bucket with "awsconfigconforms" as the bucket name prefix. We create this bucket within the Security Log Archive account to stay consistent with where our consolidated logs are stored.
 
-#### 2.3 Organization Conformance Pack <!-- omit in toc -->
+#### 2.3 Organization Conformance Pack<!-- omit in toc -->
 
 - The Organization conformance pack template is deployed to each provided region within the `delegated administrator account` and all accounts within the AWS Organization (except excluded accounts)
 
 ---
 
-### 3.0 Audit Account <!-- omit in toc -->
+### 3.0 Audit Account<!-- omit in toc -->
 
-#### 3.1 AWS CloudFormation <!-- omit in toc -->
+#### 3.1 AWS CloudFormation<!-- omit in toc -->
 
 - See [1.1 AWS CloudFormation](#11-aws-cloudformation)
 
-#### 3.2 Conformance Pack Templates S3 Bucket <!-- omit in toc -->
+#### 3.2 Conformance Pack Templates S3 Bucket<!-- omit in toc -->
 
 - S3 bucket containing the conformance pack templates containing the collection of AWS Config rules
 
-#### 3.3 Organization Conformance Pack <!-- omit in toc -->
+#### 3.3 Organization Conformance Pack<!-- omit in toc -->
 
 - See [2.3 Organization Conformance Pack](#23-organization-conformance-pack)
 
 ---
 
-### 4.0 All Existing and Future Organization Member Accounts <!-- omit in toc -->
+### 4.0 All Existing and Future Organization Member Accounts<!-- omit in toc -->
 
-#### 4.1 AWS Config Service-Linked Roles <!-- omit in toc -->
+#### 4.1 AWS Config Service-Linked Roles<!-- omit in toc -->
 
 - AWS Config creates 2 service-linked roles within each AWS account which are used to setup and send data to the delivery S3 bucket
   - AWSServiceRoleForConfigMultiAccountSetup - is used for the AWS Config multi-account setup
   - AWSServiceRoleForConfigConforms - is used to send data to the delivery S3 bucket
 
-#### 4.2 Organization Conformance Pack <!-- omit in toc -->
+#### 4.2 Organization Conformance Pack<!-- omit in toc -->
 
 - See [2.3 Organization Conformance Pack](#23-organization-conformance-pack)
 
@@ -90,7 +90,7 @@ evaluate your AWS environment, use one of the sample conformance pack templates.
 
 ## Implementation Instructions
 
-### Prerequisites <!-- omit in toc -->
+### Prerequisites<!-- omit in toc -->
 
 - AWS Control Tower is deployed.
 - `aws-security-reference-architecture-examples` repository is stored on your local machine or location where you will be deploying from.
@@ -104,25 +104,25 @@ evaluate your AWS environment, use one of the sample conformance pack templates.
   - Include the Account IDs without an AWS Configuration Recorder in the pExcludedAccounts parameter when deploying the [sra-config-conformance-pack-org-deployment.yaml](templates/sra-config-conformance-pack-org-deployment.yaml) template
   - [Optional] Add the /org/config/conformance_pack_templates_bucket SSM Parameter in the `management account`
 
-### Solution Deployment <!-- omit in toc -->
+### Solution Deployment<!-- omit in toc -->
 
-#### Customizations for AWS Control Tower <!-- omit in toc -->
+#### Customizations for AWS Control Tower<!-- omit in toc -->
 
 - [Customizations for AWS Control Tower](./customizations_for_aws_control_tower)
 
-#### AWS CloudFormation <!-- omit in toc -->
+#### AWS CloudFormation<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to the `Audit account` in all target regions using the
    [sra-config-conformance-pack-org-deployment.yaml](templates/sra-config-conformance-pack-org-deployment.yaml) template file as the source.
 
-#### Verify Solution Deployment <!-- omit in toc -->
+#### Verify Solution Deployment<!-- omit in toc -->
 
 1. Log into the Audit account and navigate to the AWS Config page
 2. Verify the correct configurations have been applied to each region
    1. Conformance packs -> OrgConformsPack-Operational-Best-Practices-for-Encryption-and-Keys-\* created in each region
    2. Settings -> Delivery location set to the `awsconfigconforms-<Log Archive Account ID>-<Region>`
 
-#### Solution Delete Instructions <!-- omit in toc -->
+#### Solution Delete Instructions<!-- omit in toc -->
 
 1. In the `management account (home region)`, delete the AWS CloudFormation **StackSet** created in step 1 of the solution deployment. **Note:** there should not be any `stack instances` associated with this StackSet.
 2. Clean up the `delegated administrator` registered in the **Prerequisites**

--- a/aws_sra_examples/solutions/config/config_conformance_pack_org/customizations_for_aws_control_tower/README.md
+++ b/aws_sra_examples/solutions/config/config_conformance_pack_org/customizations_for_aws_control_tower/README.md
@@ -1,10 +1,10 @@
-# Customizations for AWS Control Tower Implementation Instructions <!-- omit in toc -->
+# Customizations for AWS Control Tower Implementation Instructions<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
 ---
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Version 1 Solution Deployment](#version-1-solution-deployment)
 - [Version 2 Solution Deployment](#version-2-solution-deployment)

--- a/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/README.md
+++ b/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/README.md
@@ -1,8 +1,8 @@
-# EC2 Default EBS Encryption <!-- omit in toc -->
+# EC2 Default EBS Encryption<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [Deployed Resource Details](#deployed-resource-details)
@@ -18,7 +18,7 @@ unencrypted snapshot. For examples of transitioning from unencrypted to encrypte
 
 Encryption by default has no effect on existing EBS volumes or snapshots.
 
-### **Considerations** <!-- omit in toc -->
+### **Considerations**<!-- omit in toc -->
 
 - Encryption by default is a Region-specific setting. If you enable it for a Region, you cannot disable it for individual volumes or snapshots in that Region.
 - When you enable encryption by default, you can launch an instance only if the instance type supports EBS encryption. For more information, see
@@ -33,60 +33,60 @@ Encryption by default has no effect on existing EBS volumes or snapshots.
 
 ![Architecture](./documentation/ec2-default-ebs-encryption.png)
 
-### 1.0 Control Tower Management Account <!-- omit in toc -->
+### 1.0 Control Tower Management Account<!-- omit in toc -->
 
-#### 1.1 AWS CloudFormation <!-- omit in toc -->
+#### 1.1 AWS CloudFormation<!-- omit in toc -->
 
 - All resources are deployed via AWS CloudFormation as a `StackSet` and `Stack Instance` within the management account or a CloudFormation `Stack` within a specific account.
 - The [Customizations for AWS Control Tower](https://aws.amazon.com/solutions/implementations/customizations-for-aws-control-tower/) solution deploys all templates as a CloudFormation `StackSet`.
 - For parameter details, review the [AWS CloudFormation templates](templates/).
 
-#### 1.2 AWS Lambda Function <!-- omit in toc -->
+#### 1.2 AWS Lambda Function<!-- omit in toc -->
 
 - The AWS Lambda Function contains the logic for configuring the EC2 default EBS encryption settings within each account and region.
 - The function is triggered by CloudFormation Create, Update, and Delete events and also by the `Control Tower Lifecycle Event Rule` when new accounts are provisioned.
 
-#### 1.3 AWS SSM Parameter Store <!-- omit in toc -->
+#### 1.3 AWS SSM Parameter Store<!-- omit in toc -->
 
 - The Lambda Function creates/updates configuration parameters within the `SSM Parameter Store` on CloudFormation events and the parameters are used when triggered by the `Control Tower Lifecycle Event Rule`, which does not send the properties on the
   event like CloudFormation does.
 
-#### 1.4 AWS Control Tower Lifecycle Event Rule <!-- omit in toc -->
+#### 1.4 AWS Control Tower Lifecycle Event Rule<!-- omit in toc -->
 
 - The AWS Control Tower Lifecycle Event Rule triggers the `AWS Lambda Function` when a new AWS Account is provisioned through AWS Control Tower.
 
-#### 1.5 AWS Lambda CloudWatch Log Group <!-- omit in toc -->
+#### 1.5 AWS Lambda CloudWatch Log Group<!-- omit in toc -->
 
 - All the `AWS Lambda Function` logs are sent to a CloudWatch Log Group `</aws/lambda/<LambdaFunctionName>` to help with debugging and traceability of the actions performed.
 - By default the `AWS Lambda Function` will create the CloudWatch Log Group with a `Retention` (Never expire) and are encrypted with a CloudWatch Logs service managed encryption key.
 - Optional parameters are included to allow creating the CloudWatch Log Group, which allows setting `KMS Encryption` using a customer managed KMS key and setting the `Retention` to a specific value (e.g. 14 days).
 
-#### 1.6 AWS Lambda Function Role <!-- omit in toc -->
+#### 1.6 AWS Lambda Function Role<!-- omit in toc -->
 
 - The AWS Lambda Function Role allows the AWS Lambda service to assume the role and perform actions defined in the attached IAM policies.
 - The role is also trusted by the EC2 Default EBS Encryption IAM Role within each account so that it can configure the default EBS encryption account settings.
 
-#### 1.7 EC2 Default EBS Encryption IAM Role <!-- omit in toc -->
+#### 1.7 EC2 Default EBS Encryption IAM Role<!-- omit in toc -->
 
 - The EC2 default EBS encryption IAM role is deployed into each account within the AWS Organization and it is assumed by the central `AWS Lambda Function` to configure the default encryption setting for the account and region.
 
-#### 1.8 EC2 Default EBS Encryption <!-- omit in toc -->
+#### 1.8 EC2 Default EBS Encryption<!-- omit in toc -->
 
 - The `AWS Lambda Function` configures the default EBS encryption for the account and region with the `AWS managed EBS encryption key` (alias/aws/ebs).
 
 ---
 
-### 2.0 All Existing and Future Organization Member Accounts <!-- omit in toc -->
+### 2.0 All Existing and Future Organization Member Accounts<!-- omit in toc -->
 
-#### 2.1 AWS CloudFormation <!-- omit in toc -->
+#### 2.1 AWS CloudFormation<!-- omit in toc -->
 
 - See [1.1 AWS CloudFormation](#11-aws-cloudformation)
 
-#### 2.2 EC2 Default EBS Encryption IAM Role <!-- omit in toc -->
+#### 2.2 EC2 Default EBS Encryption IAM Role<!-- omit in toc -->
 
 - See [1.7 EC2 Default EBS Encryption IAM Role](#17-ec2-default-ebs-encryption-iam-role)
 
-#### 2.3 EC2 Default EBS Encryption <!-- omit in toc -->
+#### 2.3 EC2 Default EBS Encryption<!-- omit in toc -->
 
 - See [1.8 EC2 Default EBS Encryption](#18-ec2-default-ebs-encryption)
 
@@ -94,14 +94,14 @@ Encryption by default has no effect on existing EBS volumes or snapshots.
 
 ## Implementation Instructions
 
-### Prerequisites <!-- omit in toc -->
+### Prerequisites<!-- omit in toc -->
 
 - AWS Control Tower is deployed.
 - No AWS Organizations Service Control Policies (SCPs) are blocking the `ec2:GetEbsEncryptionByDefault` and `ec2:EnableEbsEncryptionByDefault` API actions
 - All targeted regions need to be enabled in all accounts within the AWS Organization
 - `aws-security-reference-architecture-examples` repository is stored on your local machine or location where you will be deploying from.
 
-### Staging <!-- omit in toc -->
+### Staging<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch the AWS CloudFormation **Stack** using the [prereq-controltower-execution-role.yaml](../../../utils/aws_control_tower/prerequisites/prereq-controltower-execution-role.yaml) template file as the
    source, to implement the `AWSControlTowerExecution` role pre-requisite.
@@ -145,13 +145,13 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 --src_dir "$SRA_REPO"/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/lambda/src
 ```
 
-### Solution Deployment <!-- omit in toc -->
+### Solution Deployment<!-- omit in toc -->
 
-#### Customizations for AWS Control Tower <!-- omit in toc -->
+#### Customizations for AWS Control Tower<!-- omit in toc -->
 
 - [Customizations for AWS Control Tower](./customizations_for_aws_control_tower)
 
-#### AWS CloudFormation <!-- omit in toc -->
+#### AWS CloudFormation<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to `All active accounts (home region)` using the [sra-ec2-default-ebs-encryption-role.yaml](templates/sra-ec2-default-ebs-encryption-role.yaml)
    template file as the source.
@@ -162,14 +162,14 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
       2. `false` = All default AWS enabled regions
    2. Enabled Regions = User provided regions. **Leave blank to enable all regions**. **Note:** All provided regions need to be enabled in all accounts within the AWS Organization.
 
-#### Verify Solution Deployment <!-- omit in toc -->
+#### Verify Solution Deployment<!-- omit in toc -->
 
 1. How to verify after the pipeline completes?
    1. Log into an account and navigate to the EC2 console page
    2. Select a region where the EBS default encryption was enabled
    3. Select the `EBS Encryption` from the `Account attributes` section and verify the settings match the parameters provided in the configuration
 
-#### Solution Delete Instructions <!-- omit in toc -->
+#### Solution Delete Instructions<!-- omit in toc -->
 
 1. In the `management account (home region)`, delete the AWS CloudFormation **Stack** created in step 3 of the solution deployment. **Note:** The solution will not modify the default EBS encryption setting on a `Delete` event. Only the SSM
    configuration parameter is deleted in this step.

--- a/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/customizations_for_aws_control_tower/README.md
+++ b/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/customizations_for_aws_control_tower/README.md
@@ -1,10 +1,10 @@
-# Customizations for AWS Control Tower Implementation Instructions <!-- omit in toc -->
+# Customizations for AWS Control Tower Implementation Instructions<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
 ---
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Version 1 Solution Deployment](#version-1-solution-deployment)
 - [Version 2 Solution Deployment](#version-2-solution-deployment)

--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/README.md
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/README.md
@@ -1,8 +1,8 @@
-# Firewall Manager <!-- omit in toc -->
+# Firewall Manager<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [Deployed Resource Details](#deployed-resource-details)
@@ -24,40 +24,40 @@ resources that you want to protect. To use Firewall Manager, your account must b
 
 ![Architecture](./documentation/firewall-manager-org.png)
 
-### 1.0 Organization Management Account <!-- omit in toc -->
+### 1.0 Organization Management Account<!-- omit in toc -->
 
-#### 1.1 AWS CloudFormation <!-- omit in toc -->
+#### 1.1 AWS CloudFormation<!-- omit in toc -->
 
 - All resources are deployed via AWS CloudFormation as a `StackSet` and `Stack Instance` within the management account or a CloudFormation `Stack` within a specific account.
 - The [Customizations for AWS Control Tower](https://aws.amazon.com/solutions/implementations/customizations-for-aws-control-tower/) solution deploys all templates as a CloudFormation `StackSet`.
 - For parameter details, review the [AWS CloudFormation templates](templates/).
 
-#### 1.2 AWS Lambda Function <!-- omit in toc -->
+#### 1.2 AWS Lambda Function<!-- omit in toc -->
 
 The Lambda function contains logic to associate a delegated administrator account for Firewall Manager
 
-#### 1.3 Lambda Execution IAM Role <!-- omit in toc -->
+#### 1.3 Lambda Execution IAM Role<!-- omit in toc -->
 
 - IAM role used by the Lambda function to configure the Firewall Delegated Administrator Account
 
-#### 1.4 Lambda CloudWatch Log Group <!-- omit in toc -->
+#### 1.4 Lambda CloudWatch Log Group<!-- omit in toc -->
 
 - All the `AWS Lambda Function` logs are sent to a CloudWatch Log Group `</aws/lambda/<LambdaFunctionName>` to help with debugging and traceability of the actions performed.
 - By default the `AWS Lambda Function` will create the CloudWatch Log Group with a `Retention` (14 days) and are encrypted with a CloudWatch Logs service managed encryption key.
 
-#### 1.5 Firewall Manager <!-- omit in toc -->
+#### 1.5 Firewall Manager<!-- omit in toc -->
 
 - Firewall Manager APIs are used to delegate an administrator account.
 
 ---
 
-### 2.0 Audit Account <!-- omit in toc -->
+### 2.0 Audit Account<!-- omit in toc -->
 
-#### 2.1 AWS CloudFormation <!-- omit in toc -->
+#### 2.1 AWS CloudFormation<!-- omit in toc -->
 
 - See [1.1 AWS CloudFormation](#11-aws-cloudformation)
 
-#### 2.2 VPC and Security Group <!-- omit in toc -->
+#### 2.2 VPC and Security Group<!-- omit in toc -->
 
 - A security group is used by the Firewall Manager security group policy to define the maximum allowed rules.
 - A VPC is required for creating the security group.
@@ -78,7 +78,7 @@ The Lambda function contains logic to associate a delegated administrator accoun
     - This Security Group policy specifically targets unused Security groups.
     - If remediation is enabled, Firewall Manager will automatically clean up security groups that are not actively being used to maintain good hygiene in the AWS environment.
 
-#### 2.3 Firewall Manager <!-- omit in toc -->
+#### 2.3 Firewall Manager<!-- omit in toc -->
 
 - This solution utilizes AWS Firewall Manager to deploy a baseline set of [AWS Managed WAF Rules](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html) to monitor and remediate the configured resources within the
   AWS Organization.
@@ -136,7 +136,7 @@ The Lambda function contains logic to associate a delegated administrator accoun
       - Key: workload-os
       - Value: posix
 
-#### 2.4 Firewall Manager Disassociate IAM Role <!-- omit in toc -->
+#### 2.4 Firewall Manager Disassociate IAM Role<!-- omit in toc -->
 
 - The Firewall Manager Disassociate IAM role is deployed to the `delegated administrator account` to disassociate the account from Firewall Manager when the solution is deleted.
 - Firewall Manager requires the disassociation to happen within the `delegated administrator account`. The `management account` Lambda function assumes this role to disassociate the account when the custom resource is deleted via CloudFormation.
@@ -145,12 +145,12 @@ The Lambda function contains logic to associate a delegated administrator accoun
 
 ## Implementation Instructions
 
-### Prerequisites <!-- omit in toc -->
+### Prerequisites<!-- omit in toc -->
 
 - AWS Control Tower is deployed.
 - `aws-security-reference-architecture-examples` repository is stored on your local machine or location where you will be deploying from.
 
-### Staging <!-- omit in toc -->
+### Staging<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch the AWS CloudFormation **Stack** using the [prereq-controltower-execution-role.yaml](../../../utils/aws_control_tower/prerequisites/prereq-controltower-execution-role.yaml) template file as the
    source, to implement the `AWSControlTowerExecution` role pre-requisite.
@@ -194,13 +194,13 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 --src_dir "$SRA_REPO"/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/lambda/src
 ```
 
-### Solution Deployment <!-- omit in toc -->
+### Solution Deployment<!-- omit in toc -->
 
-#### Customizations for AWS Control Tower <!-- omit in toc -->
+#### Customizations for AWS Control Tower<!-- omit in toc -->
 
 - [Customizations for AWS Control Tower](./customizations_for_aws_control_tower)
 
-#### AWS CloudFormation <!-- omit in toc -->
+#### AWS CloudFormation<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch an AWS CloudFormation **Stack** using the [sra-firewall-manager-org-delegate-admin.yaml](templates/sra-firewall-manager-org-delegate-admin.yaml) template file as the source.
 2. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to the `Audit account (home region)` using the
@@ -210,7 +210,7 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 4. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to the `Audit account (home region)` using the [sra-firewall-manager-org-waf-policy.yaml](templates/sra-firewall-manager-org-waf-policy.yaml) template
    file as the source.
 
-#### Verify Solution Deployment <!-- omit in toc -->
+#### Verify Solution Deployment<!-- omit in toc -->
 
 1. Log into the Audit account and navigate to the AWS Firewall Manager page
 2. Verify the correct configurations have been applied
@@ -222,7 +222,7 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
       - fms-regional-waf-linux-policy
       - fms-regional-waf-posix-policy
 
-#### Solution Delete Instructions <!-- omit in toc -->
+#### Solution Delete Instructions<!-- omit in toc -->
 
 1. In the `management account (home region)`, delete the AWS CloudFormation **StackSet** created in step 4 of the solution deployment. **Note:** there should not be any `stack instances` associated with this StackSet.
 2. In the `management account (home region)`, delete the AWS CloudFormation **StackSet** created in step 3 of the solution deployment. **Note:** there should not be any `stack instances` associated with this StackSet.
@@ -234,7 +234,7 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 
 ## Appendix
 
-### CloudFormation StackSet Instructions <!-- omit in toc -->
+### CloudFormation StackSet Instructions<!-- omit in toc -->
 
 If you need to launch an AWS CloudFormation **StackSet** in the `management account`, see below steps (for additional details, see
 [Create a stack set with self-managed permissions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-getting-started-create.html#stacksets-getting-started-create-self-managed))

--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/customizations_for_aws_control_tower/README.md
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/customizations_for_aws_control_tower/README.md
@@ -1,10 +1,10 @@
-# Customizations for AWS Control Tower Implementation Instructions <!-- omit in toc -->
+# Customizations for AWS Control Tower Implementation Instructions<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
 ---
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Version 1 Solution Deployment](#version-1-solution-deployment)
 - [Version 2 Solution Deployment](#version-2-solution-deployment)

--- a/aws_sra_examples/solutions/guardduty/guardduty_org/README.md
+++ b/aws_sra_examples/solutions/guardduty/guardduty_org/README.md
@@ -1,4 +1,4 @@
-# GuardDuty Organization <!-- omit in toc -->
+# GuardDuty Organization<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
@@ -24,77 +24,77 @@ future AWS Organization accounts. GuardDuty is also configured to send the findi
 
 ![Architecture](./documentation/guardduty-org.png)
 
-### 1.0 Organization Management Account <!-- omit in toc -->
+### 1.0 Organization Management Account<!-- omit in toc -->
 
-#### 1.1 AWS CloudFormation <!-- omit in toc -->
+#### 1.1 AWS CloudFormation<!-- omit in toc -->
 
 - All resources are deployed via AWS CloudFormation as a `StackSet` and `Stack Instance` within the management account or a CloudFormation `Stack` within a specific account.
 - The [Customizations for AWS Control Tower](https://aws.amazon.com/solutions/implementations/customizations-for-aws-control-tower/) solution deploys all templates as a CloudFormation `StackSet`.
 - For parameter details, review the [AWS CloudFormation templates](templates/).
 
-#### 1.2 AWS Lambda Function <!-- omit in toc -->
+#### 1.2 AWS Lambda Function<!-- omit in toc -->
 
 - The Lambda function includes logic to enable and configure GuardDuty
 
-#### 1.3 Lambda CloudWatch Log Group <!-- omit in toc -->
+#### 1.3 Lambda CloudWatch Log Group<!-- omit in toc -->
 
 - All the `AWS Lambda Function` logs are sent to a CloudWatch Log Group `</aws/lambda/<LambdaFunctionName>` to help with debugging and traceability of the actions performed.
 - By default the `AWS Lambda Function` will create the CloudWatch Log Group and logs are encrypted with a CloudWatch Logs service managed encryption key.
 
-#### 1.4 Lambda Execution IAM Role <!-- omit in toc -->
+#### 1.4 Lambda Execution IAM Role<!-- omit in toc -->
 
 - IAM role used by the Lambda function to enable the GuardDuty Delegated Administrator Account within each region provided
 
-#### 1.5 GuardDuty <!-- omit in toc -->
+#### 1.5 GuardDuty<!-- omit in toc -->
 
 - GuardDuty is enabled for each existing active account and region during the initial setup
 - GuardDuty will automatically enable new member accounts/regions when added to the AWS Organization
 
 ---
 
-### 2.0 Security Log Archive Account <!-- omit in toc -->
+### 2.0 Security Log Archive Account<!-- omit in toc -->
 
-#### 2.1 AWS CloudFormation <!-- omit in toc -->
+#### 2.1 AWS CloudFormation<!-- omit in toc -->
 
 - See [1.1 AWS CloudFormation](#11-aws-cloudformation)
 
-#### 2.2 GuardDuty Delivery S3 Bucket <!-- omit in toc -->
+#### 2.2 GuardDuty Delivery S3 Bucket<!-- omit in toc -->
 
 - S3 bucket where GuardDuty findings are exported for each account/region within the AWS Organization
 
-#### 2.3 GuardDuty <!-- omit in toc -->
+#### 2.3 GuardDuty<!-- omit in toc -->
 
 - See [1.5 GuardDuty](#15-guardduty)
 
 ---
 
-### 3.0 Audit Account <!-- omit in toc -->
+### 3.0 Audit Account<!-- omit in toc -->
 
-#### 3.1 AWS CloudFormation <!-- omit in toc -->
+#### 3.1 AWS CloudFormation<!-- omit in toc -->
 
 - See [1.1 AWS CloudFormation](#11-aws-cloudformation)
 
-#### 3.2 GuardDuty Delivery KMS Key <!-- omit in toc -->
+#### 3.2 GuardDuty Delivery KMS Key<!-- omit in toc -->
 
 - GuardDuty is configured to encrypt the exported findings with a customer managed KMS key
 
-#### 3.3 Configuration IAM Role <!-- omit in toc -->
+#### 3.3 Configuration IAM Role<!-- omit in toc -->
 
 - IAM role assumed by the Lambda function within the management account to configure GuardDuty within each region provided
 
-#### 3.4 GuardDuty <!-- omit in toc -->
+#### 3.4 GuardDuty<!-- omit in toc -->
 
 - See [1.5 GuardDuty](#15-guardduty)
 
 ---
 
-### 4.0 All Existing and Future Organization Member Accounts <!-- omit in toc -->
+### 4.0 All Existing and Future Organization Member Accounts<!-- omit in toc -->
 
-#### 4.1 GuardDuty <!-- omit in toc -->
+#### 4.1 GuardDuty<!-- omit in toc -->
 
 - See [1.5 GuardDuty](#15-guardduty)
 
-#### 4.2 Delete Detector Role <!-- omit in toc -->
+#### 4.2 Delete Detector Role<!-- omit in toc -->
 
 - An IAM role is created within all the accounts to clean up the GuardDuty detectors in a CloudFormation delete event
 
@@ -102,13 +102,13 @@ future AWS Organization accounts. GuardDuty is also configured to send the findi
 
 ## Implementation Instructions
 
-### Prerequisites <!-- omit in toc -->
+### Prerequisites<!-- omit in toc -->
 
 - AWS Control Tower is deployed.
 - `aws-security-reference-architecture-examples` repository is stored on your local machine or location where you will be deploying from.
 - GuardDuty is not enabled in any of the accounts within the AWS Organization
 
-### Staging <!-- omit in toc -->
+### Staging<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch the AWS CloudFormation **Stack** using the [prereq-controltower-execution-role.yaml](../../../utils/aws_control_tower/prerequisites/prereq-controltower-execution-role.yaml) template file as the
    source, to implement the `AWSControlTowerExecution` role pre-requisite.
@@ -152,13 +152,13 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 --src_dir "$SRA_REPO"/aws_sra_examples/solutions/guardduty/guardduty_org/lambda/src
 ```
 
-### Solution Deployment <!-- omit in toc -->
+### Solution Deployment<!-- omit in toc -->
 
-#### Customizations for AWS Control Tower <!-- omit in toc -->
+#### Customizations for AWS Control Tower<!-- omit in toc -->
 
 - [Customizations for AWS Control Tower](./customizations_for_aws_control_tower)
 
-#### AWS CloudFormation <!-- omit in toc -->
+#### AWS CloudFormation<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to the `Audit account (home region)` using the [sra-guardduty-org-configuration-role.yaml](templates/sra-guardduty-org-configuration-role.yaml)
    template file as the source.
@@ -169,7 +169,7 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 4. In the `management account (home region)`, launch an AWS CloudFormation **Stack** using the [sra-guardduty-org-configuration.yaml](templates/sra-guardduty-org-configuration.yaml) template file as the source.
 5. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to `All active accounts (home region)` using the [sra-guardduty-org-delete-detector-role.yaml](templates/sra-guardduty-org-delete-detector-role.yaml)
 
-#### Verify Solution Deployment <!-- omit in toc -->
+#### Verify Solution Deployment<!-- omit in toc -->
 
 1. Log into the Management account and navigate to the GuardDuty page
    1. Validate that the delegated admin account is set for each region
@@ -181,7 +181,7 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 3. Log into the Log archive account and navigate to the S3 page
    1. Verify the sample findings have been delivered
 
-#### Solution Delete Instructions <!-- omit in toc -->
+#### Solution Delete Instructions<!-- omit in toc -->
 
 1. In the `management account (home region)`, delete the AWS CloudFormation **Stack** created in step 4 of the solution deployment.
 2. In the `management account (home region)`, delete the AWS CloudFormation **StackSet** created in step 5 of the solution deployment. **Note:** there should not be any `stack instances` associated with this StackSet.
@@ -195,7 +195,7 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 
 ## Appendix
 
-### CloudFormation StackSet Instructions <!-- omit in toc -->
+### CloudFormation StackSet Instructions<!-- omit in toc -->
 
 If you need to launch an AWS CloudFormation **StackSet** in the `management account`, see below steps (for additional details, see
 [Create a stack set with self-managed permissions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-getting-started-create.html#stacksets-getting-started-create-self-managed))

--- a/aws_sra_examples/solutions/guardduty/guardduty_org/customizations_for_aws_control_tower/README.md
+++ b/aws_sra_examples/solutions/guardduty/guardduty_org/customizations_for_aws_control_tower/README.md
@@ -1,10 +1,10 @@
-# Customizations for AWS Control Tower Implementation Instructions <!-- omit in toc -->
+# Customizations for AWS Control Tower Implementation Instructions<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
 ---
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Version 1 Solution Deployment](#version-1-solution-deployment)
 - [Version 2 Solution Deployment](#version-2-solution-deployment)

--- a/aws_sra_examples/solutions/iam/iam_access_analyzer/README.md
+++ b/aws_sra_examples/solutions/iam/iam_access_analyzer/README.md
@@ -1,8 +1,8 @@
-# Access Analyzer <!-- omit in toc -->
+# Access Analyzer<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [Deployed Resource Details](#deployed-resource-details)
@@ -24,48 +24,48 @@ In addition to the organization deployment, the solution deploys AWS Access Anal
 
 ![Architecture](./documentation/iam-access-analyzer.png)
 
-### 1.0 Organization Management Account <!-- omit in toc -->
+### 1.0 Organization Management Account<!-- omit in toc -->
 
-#### 1.1 AWS CloudFormation <!-- omit in toc -->
+#### 1.1 AWS CloudFormation<!-- omit in toc -->
 
 - All resources are deployed via AWS CloudFormation as a `StackSet` and `Stack Instance` within the management account or a CloudFormation `Stack` within a specific account.
 - The [Customizations for AWS Control Tower](https://aws.amazon.com/solutions/implementations/customizations-for-aws-control-tower/) solution deploys all templates as a CloudFormation `StackSet`.
 - For parameter details, review the [AWS CloudFormation templates](templates/).
 
-#### 1.2 AWS Organizations <!-- omit in toc -->
+#### 1.2 AWS Organizations<!-- omit in toc -->
 
 - AWS Organizations is used to delegate an administrator account for AWS Access Analyzer Delegated Administrator Account
 - See [Common Register Delegated Administrator](../../common/common_register_delegated_administrator)
 
-#### 1.3 Account AWS IAM Access Analyzer <!-- omit in toc -->
+#### 1.3 Account AWS IAM Access Analyzer<!-- omit in toc -->
 
 AWS IAM Access Analyzer is configured to monitor [supported resources](https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-resources.html) for the AWS Account zone of trust.
 
 ---
 
-### 2.0 Audit Account <!-- omit in toc -->
+### 2.0 Audit Account<!-- omit in toc -->
 
-#### 2.1 AWS CloudFormation <!-- omit in toc -->
+#### 2.1 AWS CloudFormation<!-- omit in toc -->
 
 - See [1.1 AWS CloudFormation](#11-aws-cloudformation)
 
-#### 2.2 Account AWS IAM Access Analyzer <!-- omit in toc -->
+#### 2.2 Account AWS IAM Access Analyzer<!-- omit in toc -->
 
 - See [1.2 Account AWS IAM Access Analyzer](#12-account-aws-iam-access-analyzer)
 
-#### 2.3 Organization AWS IAM Access Analyzer <!-- omit in toc -->
+#### 2.3 Organization AWS IAM Access Analyzer<!-- omit in toc -->
 
 - AWS IAM Access Analyzer is configured to monitor supported resources for the AWS Organization zone of trust.
 
 ---
 
-### 3.0 All Existing and Future Organization Member Accounts <!-- omit in toc -->
+### 3.0 All Existing and Future Organization Member Accounts<!-- omit in toc -->
 
-#### 3.1 AWS CloudFormation <!-- omit in toc -->
+#### 3.1 AWS CloudFormation<!-- omit in toc -->
 
 - See [1.1 AWS CloudFormation](#11-aws-cloudformation)
 
-#### 3.2 Account AWS IAM Access Analyzer <!-- omit in toc -->
+#### 3.2 Account AWS IAM Access Analyzer<!-- omit in toc -->
 
 - See [1.2 Account AWS IAM Access Analyzer](#12-account-aws-iam-access-analyzer)
 
@@ -73,35 +73,35 @@ AWS IAM Access Analyzer is configured to monitor [supported resources](https://d
 
 ## Implementation Instructions
 
-### Pre-requisites <!-- omit in toc -->
+### Pre-requisites<!-- omit in toc -->
 
 1. Register a delegated administrator using the [Common Register Delegated Administrator](../../common/common_register_delegated_administrator) solution
    1. pServicePrincipalList = "access-analyzer.amazonaws.com"
 
-### [Customizations for AWS Control Tower](./customizations_for_aws_control_tower) <!-- omit in toc -->
+### [Customizations for AWS Control Tower](./customizations_for_aws_control_tower)<!-- omit in toc -->
 
-### CloudFormation StackSets <!-- omit in toc -->
+### CloudFormation StackSets<!-- omit in toc -->
 
-### Solution Deployment <!-- omit in toc -->
+### Solution Deployment<!-- omit in toc -->
 
-#### AWS Control Tower <!-- omit in toc -->
+#### AWS Control Tower<!-- omit in toc -->
 
 - [Customizations for AWS Control Tower](./customizations_for_aws_control_tower)
 
-#### AWS CloudFormation <!-- omit in toc -->
+#### AWS CloudFormation<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to `All active accounts` in all `Governed Regions` using the [sra-iam-access-analyzer-account.yaml](templates/sra-iam-access-analyzer-account.yaml)
    template file as the source. **Note:** Include the `management account` in the account list so that the IAM service-linked role is created, which is required for the next step.
 2. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to the `Audit account` in all `Governed Regions` using the [sra-iam-access-analyzer-org.yaml](templates/sra-iam-access-analyzer-org.yaml) template
    file as the source.
 
-#### Verify Solution Deployment <!-- omit in toc -->
+#### Verify Solution Deployment<!-- omit in toc -->
 
 1. Log into the Audit account and navigate to the IAM Access Analyzer page
    1. Verify that there are 2 Access Analyzers (account and organization)
    2. Verify all existing accounts/regions have an account Access Analyzer
 
-#### Solution Delete Instructions <!-- omit in toc -->
+#### Solution Delete Instructions<!-- omit in toc -->
 
 1. In the `management account (home region)`, delete the AWS CloudFormation **StackSet** created in step 2 of the solution deployment. **Note:** there should not be any `stack instances` associated with this StackSet.
 2. In the `management account (home region)`, delete the AWS CloudFormation **StackSet** created in step 1 of the solution deployment. **Note:** there should not be any `stack instances` associated with this StackSet.

--- a/aws_sra_examples/solutions/iam/iam_access_analyzer/customizations_for_aws_control_tower/README.md
+++ b/aws_sra_examples/solutions/iam/iam_access_analyzer/customizations_for_aws_control_tower/README.md
@@ -1,10 +1,10 @@
-# Customizations for AWS Control Tower Implementation Instructions <!-- omit in toc -->
+# Customizations for AWS Control Tower Implementation Instructions<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
 ---
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Version 1 Solution Deployment](#version-1-solution-deployment)
 - [Version 2 Solution Deployment](#version-2-solution-deployment)

--- a/aws_sra_examples/solutions/iam/iam_password_policy_acct/README.md
+++ b/aws_sra_examples/solutions/iam/iam_password_policy_acct/README.md
@@ -1,8 +1,8 @@
-# IAM Password Policy <!-- omit in toc -->
+# IAM Password Policy<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [Deployed Resource Details](#deployed-resource-details)
@@ -21,34 +21,34 @@ The IAM Password Policy solution updates the AWS account password policy within 
 
 ![Architecture](./documentation/iam-password-policy-acct.png)
 
-### 1.0 Organization Management Account <!-- omit in toc -->
+### 1.0 Organization Management Account<!-- omit in toc -->
 
-#### 1.1 AWS CloudFormation <!-- omit in toc -->
+#### 1.1 AWS CloudFormation<!-- omit in toc -->
 
 - All resources are deployed via AWS CloudFormation as a `StackSet` and `Stack Instance` within the management account or a CloudFormation `Stack` within a specific account.
 - The [Customizations for AWS Control Tower](https://aws.amazon.com/solutions/implementations/customizations-for-aws-control-tower/) solution deploys all templates as a CloudFormation `StackSet`.
 - For parameter details, review the [AWS CloudFormation templates](templates/).
 
-#### 1.2 AWS Lambda Function <!-- omit in toc -->
+#### 1.2 AWS Lambda Function<!-- omit in toc -->
 
 - The Lambda function includes logic to set the account password policy
 
-#### 1.3 Amazon CloudWatch Log Group <!-- omit in toc -->
+#### 1.3 Amazon CloudWatch Log Group<!-- omit in toc -->
 
 - All the `AWS Lambda Function` logs are sent to a CloudWatch Log Group `</aws/lambda/<LambdaFunctionName>` to help with debugging and traceability of the actions performed.
 - By default the `AWS Lambda Function` will create the CloudWatch Log Group and logs are encrypted with a CloudWatch Logs service managed encryption key.
 
-#### 1.4 Lambda Execution IAM Role <!-- omit in toc -->
+#### 1.4 Lambda Execution IAM Role<!-- omit in toc -->
 
 - IAM role used by the Lambda function to update the account password policy
 
-#### 1.5 IAM Password Policy <!-- omit in toc -->
+#### 1.5 IAM Password Policy<!-- omit in toc -->
 
 - AWS account password policy for IAM users
 
 ---
 
-### 2.0 All Organization Member Accounts <!-- omit in toc -->
+### 2.0 All Organization Member Accounts<!-- omit in toc -->
 
 Same configuration details as 1.0 Organization Management Account
 
@@ -56,7 +56,7 @@ Same configuration details as 1.0 Organization Management Account
 
 ## Implementation Instructions
 
-### Staging <!-- omit in toc -->
+### Staging<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch the AWS CloudFormation **Stack** using the [prereq-controltower-execution-role.yaml](../../../utils/aws_control_tower/prerequisites/prereq-controltower-execution-role.yaml) template file as the
    source, to implement the `AWSControlTowerExecution` role pre-requisite.
@@ -100,23 +100,23 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 --src_dir "$SRA_REPO"/aws_sra_examples/solutions/iam/iam_password_policy_acct/lambda/src
 ```
 
-### Solution Deployment <!-- omit in toc -->
+### Solution Deployment<!-- omit in toc -->
 
-#### Customizations for AWS Control Tower <!-- omit in toc -->
+#### Customizations for AWS Control Tower<!-- omit in toc -->
 
 - [Customizations for AWS Control Tower](./customizations_for_aws_control_tower)
 
-#### AWS CloudFormation <!-- omit in toc -->
+#### AWS CloudFormation<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to `All active accounts` within the `home region` using the [sra-iam-password-policy-acct.yaml](templates/sra-iam-password-policy-acct.yaml)
 
-#### Verify Solution Deployment <!-- omit in toc -->
+#### Verify Solution Deployment<!-- omit in toc -->
 
 1. Log into any account within the AWS Organization
    1. Navigate to the IAM -> Account settings page
    2. Verify the custom password policy settings
 
-#### Solution Delete Instructions <!-- omit in toc -->
+#### Solution Delete Instructions<!-- omit in toc -->
 
 1. In the `management account (home region)`, delete the AWS CloudFormation **StackSet** created in step 1 of the solution deployment. **Note:** there should not be any `stack instances` associated with this StackSet.
 

--- a/aws_sra_examples/solutions/iam/iam_password_policy_acct/customizations_for_aws_control_tower/README.md
+++ b/aws_sra_examples/solutions/iam/iam_password_policy_acct/customizations_for_aws_control_tower/README.md
@@ -1,10 +1,10 @@
-# Customizations for AWS Control Tower Implementation Instructions <!-- omit in toc -->
+# Customizations for AWS Control Tower Implementation Instructions<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
 ---
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Version 1 Solution Deployment](#version-1-solution-deployment)
 - [Version 2 Solution Deployment](#version-2-solution-deployment)

--- a/aws_sra_examples/solutions/macie/macie_org/README.md
+++ b/aws_sra_examples/solutions/macie/macie_org/README.md
@@ -1,8 +1,8 @@
-# Macie Organization <!-- omit in toc -->
+# Macie Organization<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [Deployed Resource Details](#deployed-resource-details)
@@ -23,77 +23,77 @@ Organization accounts. Macie is also configured to send the findings to a centra
 
 ![Architecture](./documentation/macie-org.png)
 
-### 1.0 Organization Management Account <!-- omit in toc -->
+### 1.0 Organization Management Account<!-- omit in toc -->
 
-#### 1.1 AWS CloudFormation <!-- omit in toc -->
+#### 1.1 AWS CloudFormation<!-- omit in toc -->
 
 - All resources are deployed via AWS CloudFormation as a `StackSet` and `Stack Instance` within the management account or a CloudFormation `Stack` within a specific account.
 - The [Customizations for AWS Control Tower](https://aws.amazon.com/solutions/implementations/customizations-for-aws-control-tower/) solution deploys all templates as a CloudFormation `StackSet`.
 - For parameter details, review the [AWS CloudFormation templates](templates/).
 
-#### 1.2 AWS Lambda Function <!-- omit in toc -->
+#### 1.2 AWS Lambda Function<!-- omit in toc -->
 
 The Lambda function is required to register the Macie delegated administrator account within each region provided
 
-#### 1.3 Lambda CloudWatch Log Group <!-- omit in toc -->
+#### 1.3 Lambda CloudWatch Log Group<!-- omit in toc -->
 
 - All the `AWS Lambda Function` logs are sent to a CloudWatch Log Group `</aws/lambda/<LambdaFunctionName>` to help with debugging and traceability of the actions performed.
 - By default the `AWS Lambda Function` will create the CloudWatch Log Group and logs are encrypted with a CloudWatch Logs service managed encryption key.
 
-#### 1.4 Lambda Execution IAM Role <!-- omit in toc -->
+#### 1.4 Lambda Execution IAM Role<!-- omit in toc -->
 
 - IAM role used by the Lambda function to register the Macie delegated administrator account within each region provided
 
-#### 1.5 Macie <!-- omit in toc -->
+#### 1.5 Macie<!-- omit in toc -->
 
 - Macie is enabled for each existing active account and region during the initial setup
 - Macie will automatically enable new member accounts/regions when added to the AWS Organization
 
 ---
 
-### 2.0 Security Log Archive Account <!-- omit in toc -->
+### 2.0 Security Log Archive Account<!-- omit in toc -->
 
-#### 2.1 AWS CloudFormation <!-- omit in toc -->
+#### 2.1 AWS CloudFormation<!-- omit in toc -->
 
 - See [1.1 AWS CloudFormation](#11-aws-cloudformation)
 
-#### 2.2 Macie Delivery S3 Bucket <!-- omit in toc -->
+#### 2.2 Macie Delivery S3 Bucket<!-- omit in toc -->
 
 - S3 bucket where Macie classifications are exported for each account/region within the AWS Organization
 
-#### 2.3 Macie <!-- omit in toc -->
+#### 2.3 Macie<!-- omit in toc -->
 
 - See [1.5 Macie](#15-macie)
 
 ---
 
-### 3.0 Audit Account <!-- omit in toc -->
+### 3.0 Audit Account<!-- omit in toc -->
 
-#### 3.1 AWS CloudFormation <!-- omit in toc -->
+#### 3.1 AWS CloudFormation<!-- omit in toc -->
 
 - See [1.1 AWS CloudFormation](#11-aws-cloudformation)
 
-#### 3.2 Macie KMS Key <!-- omit in toc -->
+#### 3.2 Macie KMS Key<!-- omit in toc -->
 
 - Macie is configured to encrypt the exported findings with a customer managed KMS key
 
-#### 3.3 Configuration IAM Role <!-- omit in toc -->
+#### 3.3 Configuration IAM Role<!-- omit in toc -->
 
 - IAM role assumed by the Lambda function within the management account to configure Macie within each region provided
 
-#### 3.4 Macie <!-- omit in toc -->
+#### 3.4 Macie<!-- omit in toc -->
 
 - See [1.5 Macie](#15-macie)
 
 ---
 
-### 4.0 All Existing and Future Organization Member Accounts <!-- omit in toc -->
+### 4.0 All Existing and Future Organization Member Accounts<!-- omit in toc -->
 
-#### 4.1 Macie <!-- omit in toc -->
+#### 4.1 Macie<!-- omit in toc -->
 
 - See [1.5 Macie](#15-macie)
 
-#### 4.2 Disable Macie Role <!-- omit in toc -->
+#### 4.2 Disable Macie Role<!-- omit in toc -->
 
 - An IAM role is created within all the accounts to disable Macie in a CloudFormation delete event
 
@@ -101,13 +101,13 @@ The Lambda function is required to register the Macie delegated administrator ac
 
 ## Implementation Instructions
 
-### Prerequisites <!-- omit in toc -->
+### Prerequisites<!-- omit in toc -->
 
 - AWS Control Tower is deployed.
 - `aws-security-reference-architecture-examples` repository is stored on your local machine or location where you will be deploying from.
 - Macie is not enabled in any of the accounts within the AWS Organization
 
-### Staging <!-- omit in toc -->
+### Staging<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch the AWS CloudFormation **Stack** using the [prereq-controltower-execution-role.yaml](../../../utils/aws_control_tower/prerequisites/prereq-controltower-execution-role.yaml) template file as the
    source, to implement the `AWSControlTowerExecution` role pre-requisite.
@@ -151,13 +151,13 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 --src_dir "$SRA_REPO"/aws_sra_examples/solutions/macie/macie_org/lambda/src
 ```
 
-### Solution Deployment <!-- omit in toc -->
+### Solution Deployment<!-- omit in toc -->
 
-#### Customizations for AWS Control Tower <!-- omit in toc -->
+#### Customizations for AWS Control Tower<!-- omit in toc -->
 
 - [Customizations for AWS Control Tower](./customizations_for_aws_control_tower)
 
-#### AWS CloudFormation <!-- omit in toc -->
+#### AWS CloudFormation<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to the `Audit account (home region)` using the [sra-macie-org-configuration-role.yaml](templates/sra-macie-org-configuration-role.yaml) template file
    as the source.
@@ -167,7 +167,7 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 4. In the `management account (home region)`, launch an AWS CloudFormation **Stack** using the [sra-macie-org-configuration.yaml](templates/sra-macie-org-configuration.yaml) template file as the source.
 5. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to `All active accounts (home region)` using the [sra-macie-org-member-disable-role.yaml](templates/sra-macie-org-member-disable-role.yaml)
 
-#### Verify Solution Deployment <!-- omit in toc -->
+#### Verify Solution Deployment<!-- omit in toc -->
 
 1. Log into the Management account and navigate to the Macie page
    1. Validate that the delegated admin account is set for each region
@@ -179,7 +179,7 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 3. Log into the Log archive account and navigate to the S3 page
    1. Verify the sample findings have been delivered
 
-#### Solution Delete Instructions <!-- omit in toc -->
+#### Solution Delete Instructions<!-- omit in toc -->
 
 1. In the `management account (home region)`, delete the AWS CloudFormation **Stack** created in step 4 of the solution deployment.
 2. In the `management account (home region)`, delete the AWS CloudFormation **StackSet** created in step 5 of the solution deployment. **Note:** there should not be any `stack instances` associated with this StackSet.
@@ -193,7 +193,7 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 
 ## Appendix
 
-### CloudFormation StackSet Instructions <!-- omit in toc -->
+### CloudFormation StackSet Instructions<!-- omit in toc -->
 
 If you need to launch an AWS CloudFormation **StackSet** in the `management account`, see below steps (for additional details, see
 [Create a stack set with self-managed permissions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-getting-started-create.html#stacksets-getting-started-create-self-managed))

--- a/aws_sra_examples/solutions/macie/macie_org/customizations_for_aws_control_tower/README.md
+++ b/aws_sra_examples/solutions/macie/macie_org/customizations_for_aws_control_tower/README.md
@@ -1,10 +1,10 @@
-# Customizations for AWS Control Tower Implementation Instructions <!-- omit in toc -->
+# Customizations for AWS Control Tower Implementation Instructions<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
 ---
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Version 1 Solution Deployment](#version-1-solution-deployment)
 - [Version 2 Solution Deployment](#version-2-solution-deployment)

--- a/aws_sra_examples/solutions/s3/s3_block_account_public_access/README.md
+++ b/aws_sra_examples/solutions/s3/s3_block_account_public_access/README.md
@@ -1,8 +1,8 @@
-# S3 Block Account Public Access <!-- omit in toc -->
+# S3 Block Account Public Access<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [Deployed Resource Details](#deployed-resource-details)
@@ -18,7 +18,7 @@ users can modify bucket policies, access point policies, or object permissions t
 
 With S3 Block Public Access, account administrators and bucket owners can easily set up centralized controls to limit public access to their Amazon S3 resources that are enforced regardless of how the resources are created.
 
-### Block public access settings <!-- omit in toc -->
+### Block public access settings<!-- omit in toc -->
 
 > **S3 Block Public Access provides four settings. This solution applies the settings to the account, which applies to all buckets and access points that are owned by that account.**
 
@@ -42,60 +42,60 @@ With S3 Block Public Access, account administrators and bucket owners can easily
 
 ![Architecture](./documentation/s3-block-account-public-access.png)
 
-### 1.0 Control Tower Management Account <!-- omit in toc -->
+### 1.0 Control Tower Management Account<!-- omit in toc -->
 
-#### 1.1 AWS CloudFormation <!-- omit in toc -->
+#### 1.1 AWS CloudFormation<!-- omit in toc -->
 
 - All resources are deployed via AWS CloudFormation as a `StackSet` and `Stack Instance` within the management account or a CloudFormation `Stack` within a specific account.
 - The [Customizations for AWS Control Tower](https://aws.amazon.com/solutions/implementations/customizations-for-aws-control-tower/) solution deploys all templates as a CloudFormation `StackSet`.
 - For parameter details, review the [AWS CloudFormation templates](templates/).
 
-#### 1.2 AWS Lambda Function <!-- omit in toc -->
+#### 1.2 AWS Lambda Function<!-- omit in toc -->
 
 - The AWS Lambda Function contains the logic for configuring the S3 block public access settings within each account.
 - The function is triggered by CloudFormation Create, Update, and Delete events and also by the `Control Tower Lifecycle Event Rule` when new accounts are provisioned.
 
-#### 1.3 AWS SSM Parameter Store <!-- omit in toc -->
+#### 1.3 AWS SSM Parameter Store<!-- omit in toc -->
 
 - The Lambda Function creates/updates configuration parameters within the `SSM Parameter Store` on CloudFormation events and the parameters are used when triggered by the `Control Tower Lifecycle Event Rule`, which does not send the properties on the
   event like CloudFormation does.
 
-#### 1.4 AWS Control Tower Lifecycle Event Rule <!-- omit in toc -->
+#### 1.4 AWS Control Tower Lifecycle Event Rule<!-- omit in toc -->
 
 - The AWS Control Tower Lifecycle Event Rule triggers the `AWS Lambda Function` when a new AWS Account is provisioned through AWS Control Tower.
 
-#### 1.5 AWS Lambda CloudWatch Log Group <!-- omit in toc -->
+#### 1.5 AWS Lambda CloudWatch Log Group<!-- omit in toc -->
 
 - All the `AWS Lambda Function` logs are sent to a CloudWatch Log Group `</aws/lambda/<LambdaFunctionName>` to help with debugging and traceability of the actions performed.
 - By default the `AWS Lambda Function` will create the CloudWatch Log Group with a `Retention` (Never expire) and are encrypted with a CloudWatch Logs service managed encryption key.
 - Optional parameters are included to allow creating the CloudWatch Log Group, which allows setting `KMS Encryption` using a customer managed KMS key and setting the `Retention` to a specific value (e.g. 14 days).
 
-#### 1.6 AWS Lambda Function Role <!-- omit in toc -->
+#### 1.6 AWS Lambda Function Role<!-- omit in toc -->
 
 - The AWS Lambda Function Role allows the AWS Lambda service to assume the role and perform actions defined in the attached IAM policies.
 - The role is also trusted by the S3 Block Account Public Access IAM Role within each account so that it can configure the S3 account settings.
 
-#### 1.7 S3 Block Account Public Access IAM Role <!-- omit in toc -->
+#### 1.7 S3 Block Account Public Access IAM Role<!-- omit in toc -->
 
 - The S3 block account public access IAM role is deployed into each account within the AWS Organization and it is assumed by the central `AWS Lambda Function` to configure the block public access settings for the account.
 
-#### 1.8 S3 Account Settings <!-- omit in toc -->
+#### 1.8 S3 Account Settings<!-- omit in toc -->
 
 - The `AWS Lambda Function` configures the block public access settings for the account.
 
 ---
 
-### 2.0 All Existing and Future Organization Member Accounts <!-- omit in toc -->
+### 2.0 All Existing and Future Organization Member Accounts<!-- omit in toc -->
 
-#### 2.1 AWS CloudFormation <!-- omit in toc -->
+#### 2.1 AWS CloudFormation<!-- omit in toc -->
 
 - See [1.1 AWS CloudFormation](#11-aws-cloudformation)
 
-#### 2.2 S3 Block Account Public Access IAM Role <!-- omit in toc -->
+#### 2.2 S3 Block Account Public Access IAM Role<!-- omit in toc -->
 
 - See [1.7 S3 Block Account Public Access IAM Role](#17-s3-block-account-public-access-iam-role)
 
-#### 2.3 S3 Account Settings <!-- omit in toc -->
+#### 2.3 S3 Account Settings<!-- omit in toc -->
 
 - See [1.8 S3 Account Settings](#18-s3-account-settings)
 
@@ -103,13 +103,13 @@ With S3 Block Public Access, account administrators and bucket owners can easily
 
 ## Implementation Instructions
 
-### Prerequisites <!-- omit in toc -->
+### Prerequisites<!-- omit in toc -->
 
 - AWS Control Tower is deployed.
 - No AWS Organizations Service Control Policies (SCPs) are blocking the `s3:GetAccountPublicAccessBlock` and `s3:PutAccountPublicAccessBlock` API actions
 - `aws-security-reference-architecture-examples` repository is stored on your local machine or location where you will be deploying from.
 
-### Staging <!-- omit in toc -->
+### Staging<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch the AWS CloudFormation **Stack** using the [prereq-controltower-execution-role.yaml](../../../utils/aws_control_tower/prerequisites/prereq-controltower-execution-role.yaml) template file as the
    source, to implement the `AWSControlTowerExecution` role pre-requisite.
@@ -153,26 +153,26 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 --src_dir "$SRA_REPO"/aws_sra_examples/solutions/s3/s3_block_account_public_access/lambda/src
 ```
 
-### Solution Deployment <!-- omit in toc -->
+### Solution Deployment<!-- omit in toc -->
 
-#### Customizations for AWS Control Tower <!-- omit in toc -->
+#### Customizations for AWS Control Tower<!-- omit in toc -->
 
 - [Customizations for AWS Control Tower](./customizations_for_aws_control_tower)
 
-#### AWS CloudFormation <!-- omit in toc -->
+#### AWS CloudFormation<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to `All active accounts (home region)` using the
    [sra-s3-block-account-public-access-role.yaml](templates/sra-s3-block-account-public-access-role.yaml) template file as the source.
 2. In the `management account (home region)`, launch an AWS CloudFormation **Stack** using the [sra-s3-block-account-public-access-role.yaml](templates/sra-s3-block-account-public-access-role.yaml) template file as the source.
 3. In the `management account (home region)`, launch the AWS CloudFormation **Stack** using the [sra-s3-block-account-public-access.yaml](templates/sra-s3-block-account-public-access.yaml) template file as the source.
 
-#### Verify Solution Deployment <!-- omit in toc -->
+#### Verify Solution Deployment<!-- omit in toc -->
 
 1. How to verify after the pipeline completes?
    1. Log into an account and navigate to the S3 console page
    2. Select the `Block Public Access settings for this account` in the side menu and verify the settings match the parameters provided in the configuration
 
-#### Solution Delete Instructions <!-- omit in toc -->
+#### Solution Delete Instructions<!-- omit in toc -->
 
 1. In the `management account (home region)`, delete the AWS CloudFormation **Stack** created in step 3 of the solution deployment. **Note:** The solution will not modify the S3 block account public access settings on a `Delete` event. Only the SSM
    configuration parameter is deleted in this step.

--- a/aws_sra_examples/solutions/s3/s3_block_account_public_access/customizations_for_aws_control_tower/README.md
+++ b/aws_sra_examples/solutions/s3/s3_block_account_public_access/customizations_for_aws_control_tower/README.md
@@ -1,10 +1,10 @@
-# Customizations for AWS Control Tower Implementation Instructions <!-- omit in toc -->
+# Customizations for AWS Control Tower Implementation Instructions<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
 ---
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Version 1 Solution Deployment](#version-1-solution-deployment)
 - [Version 2 Solution Deployment](#version-2-solution-deployment)

--- a/aws_sra_examples/solutions/securityhub/securityhub_enabler_acct/README.md
+++ b/aws_sra_examples/solutions/securityhub/securityhub_enabler_acct/README.md
@@ -1,8 +1,8 @@
-# SecurityHub Enabler Account <!-- omit in toc -->
+# SecurityHub Enabler Account<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [Deployed Resource Details](#deployed-resource-details)
@@ -28,65 +28,65 @@ This solution differs from that presented [here](https://github.com/awslabs/aws-
 
 ![Architecture](./documentation/securityhub-enabler-acct.png)
 
-### 1.0 Organization Management Account <!-- omit in toc -->
+### 1.0 Organization Management Account<!-- omit in toc -->
 
-#### 1.1 AWS CloudFormation <!-- omit in toc -->
+#### 1.1 AWS CloudFormation<!-- omit in toc -->
 
 - All resources are deployed via AWS CloudFormation as a `StackSet` and `Stack Instance` within the management account or a CloudFormation `Stack` within a specific account.
 - The [Customizations for AWS Control Tower](https://aws.amazon.com/solutions/implementations/customizations-for-aws-control-tower/) solution deploys all templates as a CloudFormation `StackSet`.
 - For parameter details, review the [AWS CloudFormation templates](templates/).
 
-#### 1.2 EventBridge Scheduled Rule <!-- omit in toc -->
+#### 1.2 EventBridge Scheduled Rule<!-- omit in toc -->
 
 - The scheduled rule triggers the Lambda Function between 1 and 3600 minutes to check organization compliance
 
-#### 1.3 SNS Topic <!-- omit in toc -->
+#### 1.3 SNS Topic<!-- omit in toc -->
 
 - SNS Topic triggers the Lambda Function during initial setup to handle multiple accounts.
 - The Lambda Function will publish all the AWS Organization accounts to the SNS Topic if it isn't triggered by SNS.
 
-#### 1.4 AWS Lambda Function <!-- omit in toc -->
+#### 1.4 AWS Lambda Function<!-- omit in toc -->
 
 - The Lambda Function enables Security Hub within all the active AWS Organizations accounts
 
-#### 1.5 Lambda CloudWatch Log Group <!-- omit in toc -->
+#### 1.5 Lambda CloudWatch Log Group<!-- omit in toc -->
 
 - Contains the Lambda function execution logs
 
-#### 1.6 Lambda Execution IAM Role <!-- omit in toc -->
+#### 1.6 Lambda Execution IAM Role<!-- omit in toc -->
 
 - Used by the custom CloudFormation Lambda function to enable Security Hub in all accounts and regions
 
-#### 1.7 Security Hub <!-- omit in toc -->
+#### 1.7 Security Hub<!-- omit in toc -->
 
 - Security Hub is enabled in all the active Organization accounts and regions via the Lambda Function.
 - Each member account Security Hub is configured with the provided Security Hub master account.
 
 ---
 
-### 2.0 Audit Account <!-- omit in toc -->
+### 2.0 Audit Account<!-- omit in toc -->
 
-#### 2.1 AWS CloudFormation <!-- omit in toc -->
+#### 2.1 AWS CloudFormation<!-- omit in toc -->
 
 - See [1.1 AWS CloudFormation](#11-aws-cloudformation)
 
-#### 2.2 Security Hub Enabler Role <!-- omit in toc -->
+#### 2.2 Security Hub Enabler Role<!-- omit in toc -->
 
 - IAM role assumed by the Management account Lambda function to enable Security Hub within each account and all the active regions
 
-#### 2.3 Security Hub <!-- omit in toc -->
+#### 2.3 Security Hub<!-- omit in toc -->
 
 - Security Hub provides visibility of all Security Hub member results
 
 ---
 
-### 3.0 All Existing and Future Organization Member Accounts <!-- omit in toc -->
+### 3.0 All Existing and Future Organization Member Accounts<!-- omit in toc -->
 
-#### 3.1 Security Hub Enabler Role <!-- omit in toc -->
+#### 3.1 Security Hub Enabler Role<!-- omit in toc -->
 
 - IAM role assumed by the Management account Lambda function to enable Security Hub within each account and all the active regions
 
-#### 3.2 Security Hub <!-- omit in toc -->
+#### 3.2 Security Hub<!-- omit in toc -->
 
 - Security Hub enabled within each account and all active regions
 
@@ -94,13 +94,13 @@ This solution differs from that presented [here](https://github.com/awslabs/aws-
 
 ## Implementation Instructions
 
-### Prerequisites <!-- omit in toc -->
+### Prerequisites<!-- omit in toc -->
 
 - AWS Control Tower is deployed.
 - `aws-security-reference-architecture-examples` repository is stored on your local machine or location where you will be deploying from.
 - Security Hub is not enabled in any of the accounts within the AWS Organization
 
-### Staging <!-- omit in toc -->
+### Staging<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch the AWS CloudFormation **Stack** using the [prereq-controltower-execution-role.yaml](../../../utils/aws_control_tower/prerequisites/prereq-controltower-execution-role.yaml) template file as the
    source, to implement the `AWSControlTowerExecution` role pre-requisite.
@@ -144,19 +144,19 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 --src_dir "$SRA_REPO"/aws_sra_examples/solutions/securityhub/securityhub_enabler_acct/lambda/src
 ```
 
-### Solution Deployment <!-- omit in toc -->
+### Solution Deployment<!-- omit in toc -->
 
-#### Customizations for AWS Control Tower <!-- omit in toc -->
+#### Customizations for AWS Control Tower<!-- omit in toc -->
 
 - [Customizations for AWS Control Tower](./customizations_for_aws_control_tower)
 
-#### AWS CloudFormation <!-- omit in toc -->
+#### AWS CloudFormation<!-- omit in toc -->
 
 1. In the `management account (home region)`, launch an AWS CloudFormation **Stack Set** and deploy to `All active accounts (home region)` using the [sra-securityhub-enabler-acct-role.yaml](templates/sra-securityhub-enabler-acct-role.yaml) template
    file as the source.
 2. In the `management account (home region)`, launch an AWS CloudFormation **Stack** using the [sra-securityhub-enabler-acct.yaml](templates/sra-securityhub-enabler-acct.yaml) template file as the source.
 
-#### Verify Solution Deployment <!-- omit in toc -->
+#### Verify Solution Deployment<!-- omit in toc -->
 
 1. Log into the Audit account and navigate to the Security Hub page
 2. Verify the correct configurations have been applied to each region
@@ -164,7 +164,7 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
    2. Settings -> Accounts enabled
    3. Integrations enabled
 
-#### Solution Delete Instructions <!-- omit in toc -->
+#### Solution Delete Instructions<!-- omit in toc -->
 
 1. In the `management account (home region)`, delete the AWS CloudFormation **Stack** created in step 2 of the solution deployment.
 2. In the `management account (home region)`, delete the AWS CloudWatch **Log Group** (e.g. /aws/lambda/<solution_name>) for the Lambda function deployed in step 2 of the solution deployment.
@@ -174,7 +174,7 @@ sh "$SRA_REPO"/aws_sra_examples/utils/packaging_scripts/package-lambda.sh \
 
 ## Appendix
 
-### CloudFormation StackSet Instructions <!-- omit in toc -->
+### CloudFormation StackSet Instructions<!-- omit in toc -->
 
 If you need to launch an AWS CloudFormation **StackSet** in the `management account`, see below steps (for additional details, see
 [Create a stack set with self-managed permissions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-getting-started-create.html#stacksets-getting-started-create-self-managed))

--- a/aws_sra_examples/solutions/securityhub/securityhub_enabler_acct/customizations_for_aws_control_tower/README.md
+++ b/aws_sra_examples/solutions/securityhub/securityhub_enabler_acct/customizations_for_aws_control_tower/README.md
@@ -1,10 +1,10 @@
-# Customizations for AWS Control Tower Implementation Instructions <!-- omit in toc -->
+# Customizations for AWS Control Tower Implementation Instructions<!-- omit in toc -->
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: CC-BY-SA-4.0
 
 ---
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Version 1 Solution Deployment](#version-1-solution-deployment)
 - [Version 2 Solution Deployment](#version-2-solution-deployment)


### PR DESCRIPTION
The space before the table of contents comment was preventing links within README files from working correctly. This fix removed the space so that the links no longer include a trailing dash.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0