### PR TITLE
reverting back to 2.0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Amazon Web Services <no_reply@amazon.com>"]
 [tool.poetry.dependencies]
 python = "^3.9"
 boto3 = "^1.18.42"
-crhelper = "^2.0.1"
+crhelper = "^2.0.10"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
Reverting the crhelper version back to 2.0.10
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
