### PR TITLE
Set ExcludeResourceTags to false for all policies

### DIFF
--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-main-ssm.yaml
@@ -9,7 +9,7 @@ Description:
 
 Metadata:
   SRA:
-    Version: 1.1
+    Version: 1.2
     Entry: Parameters for deploying solution resolving SSM parameters
     Order: 1
   AWS::CloudFormation::Interface:
@@ -152,8 +152,8 @@ Parameters:
     Description: The SRA solution name. The default value is the folder name of the solution
     Type: String
   pSRASolutionVersion:
-    AllowedValues: [v1.1]
-    Default: v1.1
+    AllowedValues: [v1.2]
+    Default: v1.2
     Description: The SRA solution version. Used to trigger updates on the nested StackSets.
     Type: String
   pSRAStagingS3BucketName:

--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-main.yaml
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-main.yaml
@@ -9,7 +9,7 @@ Description:
 
 Metadata:
   SRA:
-    Version: 1.1
+    Version: 1.2
     Entry: Parameters for deploying solution
     Order: 1
   AWS::CloudFormation::Interface:
@@ -150,8 +150,8 @@ Parameters:
     Description: The SRA solution name. The default value is the folder name of the solution
     Type: String
   pSRASolutionVersion:
-    AllowedValues: [v1.1]
-    Default: v1.1
+    AllowedValues: [v1.2]
+    Default: v1.2
     Description: The SRA solution version. Used to trigger updates on the nested StackSets.
     Type: String
   pSRAStagingS3BucketName:

--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-waf-policy.yaml
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-waf-policy.yaml
@@ -9,7 +9,7 @@ Description:
 
 Metadata:
   SRA:
-    Version: 1.1
+    Version: 1.2
     Order: 5
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -39,7 +39,7 @@ Resources:
       PolicyName: sra-fms-regional-waf-default-policy
       DeleteAllPolicyResources: true
       RemediationEnabled: true
-      ExcludeResourceTags: true
+      ExcludeResourceTags: false
       ResourceTags:
         - Key: fms-default-policy
           Value: 'true'


### PR DESCRIPTION
The ExcludeResourceTags was set to true for the first WAF example policy where all the others were set to false. This change is to update the first WAF policy to have the ExcludeResourceTags set to false keeping the template consistent across all policies.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
