### PR TITLE
Use supported action: ruby/setup-ruby

### DIFF
--- a/.github/workflows/cfn-nag.yml
+++ b/.github/workflows/cfn-nag.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby 2.6
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.6'
       - name: Install cfn-nag


### PR DESCRIPTION
Replace retired github action [actions/setup-ruby ](https://github.com/actions/setup-ruby) with supported replacement [ruby/setup-ruby](https://github.com/ruby/setup-ruby)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
