### PR TITLE
Added DeadLetterConfig to Lambda function and removed checkov suppressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
+- [2022-05-23](#2022-05-23)
 - [2022-05-15](#2022-05-15)
 - [2022-04-25](#2022-04-25)
 - [2022-04-14](#2022-04-14)
@@ -27,6 +28,16 @@
 All notable changes to this project will be documented in this file.
 
 ---
+
+## 2022-05-23
+
+### Changed<!-- omit in toc -->
+
+- [EC2 Default EBS Encryption](aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption) solution updates:
+  - Added DeadLetterConfig to the Lambda function.
+  - Removed the checkov suppression for not having a DLQ configured.
+- [S3 Block Account Public Access](aws_sra_examples/solutions/s3_block_account_public_access) solution updates:
+  - Removed the checkov suppression for not having a DLQ configured.
 
 ## 2022-05-15
 

--- a/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/templates/sra-ec2-default-ebs-encryption.yaml
+++ b/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/templates/sra-ec2-default-ebs-encryption.yaml
@@ -9,7 +9,7 @@ Description:
 
 Metadata:
   SRA:
-    Version: 1.2
+    Version: 1.3
     Order: 3
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -403,8 +403,6 @@ Resources:
             reason: Lambda does not need reserved concurrent executions.
       checkov:
         skip:
-          - id: CKV_AWS_116
-            comment: DLQ not needed.
           - id: CKV_AWS_173
             comment: Environment variables are not sensitive.
     Properties:
@@ -421,6 +419,8 @@ Resources:
       Code:
         S3Bucket: !Ref pSRAStagingS3BucketName
         S3Key: !Sub ${pSRASolutionName}/lambda_code/${pSRASolutionName}.zip
+      DeadLetterConfig:
+        TargetArn: !GetAtt rEC2DefaultEBSEncryptionDLQ.Arn
       Environment:
         Variables:
           LOG_LEVEL: !Ref pLambdaLogLevel

--- a/aws_sra_examples/solutions/s3/s3_block_account_public_access/templates/sra-s3-block-account-public-access.yaml
+++ b/aws_sra_examples/solutions/s3/s3_block_account_public_access/templates/sra-s3-block-account-public-access.yaml
@@ -9,7 +9,7 @@ Description:
 
 Metadata:
   SRA:
-    Version: 1.2
+    Version: 1.3
     Order: 3
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -323,8 +323,6 @@ Resources:
             reason: Lambda does not need reserved concurrent executions.
       checkov:
         skip:
-          - id: CKV_AWS_116
-            comment: No DLQ added.
           - id: CKV_AWS_173
             comment: Environment variables are not sensitive.
     Properties:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws_sra_examples"
-version = "2.1.1"
+version = "2.1.2"
 description = "AWS Security Reference Architecture Examples"
 authors = ["Amazon Web Services <no_reply@amazon.com>"]
 license = "MIT-0 License"


### PR DESCRIPTION
### Changed

- [EC2 Default EBS Encryption](aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption) solution updates:
  - Added DeadLetterConfig to the Lambda function.
  - Removed the checkov suppression for not having a DLQ configured.
- [S3 Block Account Public Access](aws_sra_examples/solutions/s3_block_account_public_access) solution updates:
  - Removed the checkov suppression for not having a DLQ configured.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
