### PR TITLE
Added AWS Core Ruleset in all AWF Policies (Firewall Manager)

### DIFF
--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/README.md
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/README.md
@@ -116,6 +116,7 @@ populated from the `SecurityAccountId` parameter within the `AWSControlTowerBP-B
       - ELBv2
       - API Gateway
     - AWS Managed Rule sets
+      - AWS Core Ruleset
       - AWS Windows Operating System Ruleset
     - Resource Tag
       - Key: workload-os
@@ -125,6 +126,7 @@ populated from the `SecurityAccountId` parameter within the `AWSControlTowerBP-B
       - ELBv2
       - API Gateway
     - AWS Managed Rule sets
+      - AWS Core Ruleset
       - AWS Linux Operating System Ruleset
     - Resource Tag
       - Key: workload-os
@@ -134,6 +136,7 @@ populated from the `SecurityAccountId` parameter within the `AWSControlTowerBP-B
       - ELBv2
       - API Gateway
     - AWS Managed Rule sets
+      - AWS Core Ruleset
       - AWS Posix Operating System Ruleset
     - Resource Tag
       - Key: workload-os

--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-main-ssm.yaml
@@ -9,7 +9,7 @@ Description:
 
 Metadata:
   SRA:
-    Version: 1.2
+    Version: 1.3
     Entry: Parameters for deploying solution resolving SSM parameters
     Order: 1
   AWS::CloudFormation::Interface:

--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-main.yaml
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-main.yaml
@@ -9,7 +9,7 @@ Description:
 
 Metadata:
   SRA:
-    Version: 1.2
+    Version: 1.3
     Entry: Parameters for deploying solution
     Order: 1
   AWS::CloudFormation::Interface:

--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-waf-policy.yaml
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-waf-policy.yaml
@@ -9,7 +9,7 @@ Description:
 
 Metadata:
   SRA:
-    Version: 1.2
+    Version: 1.3
     Order: 5
   AWS::CloudFormation::Interface:
     ParameterGroups:

--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-waf-policy.yaml
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-waf-policy.yaml
@@ -105,6 +105,8 @@ Resources:
         Type: WAFV2
         ManagedServiceData:
           '{ "type":"WAFV2", "defaultAction":{ "type":"ALLOW" }, "preProcessRuleGroups": [ { "managedRuleGroupIdentifier": { "vendorName": "AWS",
+          "managedRuleGroupName": "AWSManagedRulesCommonRuleSet", "version": null }, "overrideAction": { "type": "NONE" }, "ruleGroupArn": null,
+          "excludeRules": [], "ruleGroupType": "ManagedRuleGroup" }, { "managedRuleGroupIdentifier": { "vendorName": "AWS",
           "managedRuleGroupName": "AWSManagedRulesWindowsRuleSet", "version": null }, "overrideAction": { "type": "NONE" }, "ruleGroupArn": null,
           "excludeRules": [], "ruleGroupType": "ManagedRuleGroup" } ], "postProcessRuleGroups": [], "overrideCustomerWebACLAssociation":true }'
 
@@ -128,6 +130,8 @@ Resources:
         Type: WAFV2
         ManagedServiceData:
           '{ "type":"WAFV2", "defaultAction":{ "type":"ALLOW" }, "preProcessRuleGroups": [ { "managedRuleGroupIdentifier": { "vendorName": "AWS",
+          "managedRuleGroupName": "AWSManagedRulesCommonRuleSet", "version": null }, "overrideAction": { "type": "NONE" }, "ruleGroupArn": null,
+          "excludeRules": [], "ruleGroupType": "ManagedRuleGroup" }, { "managedRuleGroupIdentifier": { "vendorName": "AWS",
           "managedRuleGroupName": "AWSManagedRulesLinuxRuleSet", "version": null }, "overrideAction": { "type": "NONE" }, "ruleGroupArn": null,
           "excludeRules": [], "ruleGroupType": "ManagedRuleGroup" } ], "postProcessRuleGroups": [], "overrideCustomerWebACLAssociation":true }'
 
@@ -151,6 +155,8 @@ Resources:
         Type: WAFV2
         ManagedServiceData:
           '{ "type":"WAFV2", "defaultAction":{ "type":"ALLOW" }, "preProcessRuleGroups": [ { "managedRuleGroupIdentifier": { "vendorName": "AWS",
+          "managedRuleGroupName": "AWSManagedRulesCommonRuleSet", "version": null }, "overrideAction": { "type": "NONE" }, "ruleGroupArn": null,
+          "excludeRules": [], "ruleGroupType": "ManagedRuleGroup" }, { "managedRuleGroupIdentifier": { "vendorName": "AWS",
           "managedRuleGroupName": "AWSManagedRulesUnixRuleSet", "version": null }, "overrideAction": { "type": "NONE" }, "ruleGroupArn": null,
           "excludeRules": [], "ruleGroupType": "ManagedRuleGroup" } ], "postProcessRuleGroups": [], "overrideCustomerWebACLAssociation":true }'
 


### PR DESCRIPTION
Added AWS Core Ruleset in all AWF Policies (Firewall Manager). The Core rule set (CRS) rule group contains rules that are generally applicable to web applications. This provides protection against exploitation of a wide range of vulnerabilities, including some of the high risk and commonly occurring vulnerabilities described in OWASP publications such as [OWASP Top 10](https://owasp.org/www-project-top-ten/). Consider using this rule group for any AWS WAF use case. More information: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
