### PR TITLE
Corrected spelling error

### DIFF
--- a/aws_sra_examples/solutions/common/common_prerequisites/README.md
+++ b/aws_sra_examples/solutions/common/common_prerequisites/README.md
@@ -11,7 +11,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-
 
 ## Introduction
 
-The `SRA Prerequisites Solution` creates the resources (`Staging S3 Buckets` and `Execution IAM Role`) and configuration AWS Systems Manager Parameters (`SSM Parameters`) for simplifying the deployment of SRA solutions within an AWS Control Tower
+The `SRA Prerequisites Solution` creates the resources (`Staging S3 Buckets` and `Execution IAM Role`) and configures AWS Systems Manager Parameters (`SSM Parameters`) for simplifying the deployment of SRA solutions within an AWS Control Tower
 environment. All resources that support tags are provided a tag keypair of `sra-solution: sra-common-prerequisites`.
 
 [AWS Systems Manager](https://aws.amazon.com/systems-manager/) (SSM) has a [Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) capability that provides secure, hierarchical storage for


### PR DESCRIPTION
Corrected the following spelling error

configuration -> configures

<!-- markdownlint-disable MD041 -->
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1], use the [General Contributing Guidance] checklist,
and follow the pull-request checklist.

[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
[2]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
-->

<!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
