### PR TITLE
added missing parameters to sra-config-conformance-pack-org non-ssm s…

### DIFF
--- a/aws_sra_examples/solutions/common/common_register_delegated_administrator/templates/sra-common-register-delegated-administrator.yaml
+++ b/aws_sra_examples/solutions/common/common_register_delegated_administrator/templates/sra-common-register-delegated-administrator.yaml
@@ -259,3 +259,8 @@ Resources:
       ServiceToken: !GetAtt rRegisterDelegatedAdminLambdaFunction.Arn
       AWS_SERVICE_PRINCIPAL_LIST: !Ref pServicePrincipalList
       DELEGATED_ADMIN_ACCOUNT_ID: !Ref pDelegatedAdminAccountId
+
+Outputs:
+  oSRASolutionName:
+    Description: SRA Solution Name
+    Value: !Ref pSRASolutionName

--- a/aws_sra_examples/solutions/config/config_conformance_pack_org/customizations_for_aws_control_tower/manifest-v2.yaml
+++ b/aws_sra_examples/solutions/config/config_conformance_pack_org/customizations_for_aws_control_tower/manifest-v2.yaml
@@ -2,7 +2,6 @@
 #Default region for deploying Custom Control Tower: Code Pipeline, Step functions, Lambda, SSM parameters, and StackSets
 region: us-east-1
 version: 2021-03-15
-
 # Control Tower Custom Resources (Service Control Policies or CloudFormation)
 resources:
   # -----------------------------------------------------------------------------
@@ -41,10 +40,14 @@ resources:
   #       parameter_value: ''
   #     - parameter_key: pLogArchiveAccountId
   #       parameter_value: ''
+  #     - parameter_key: pOrganizationId
+  #       parameter_value: ''
   #     - parameter_key: pRegionsToDeployConformancePacks
   #       parameter_value: ''
   #     - parameter_key: pRegisterDelegatedAdminAccount
   #       parameter_value: 'Yes'
+  #     - parameter_key: pSRAStagingS3BucketName
+  #       parameter_value: ''
   #   deploy_method: stack_set
   #   deployment_targets:
   #     accounts:

--- a/aws_sra_examples/solutions/config/config_conformance_pack_org/templates/sra-config-conformance-pack-org-main.yaml
+++ b/aws_sra_examples/solutions/config/config_conformance_pack_org/templates/sra-config-conformance-pack-org-main.yaml
@@ -152,10 +152,12 @@ Resources:
         - Key: sra-solution
           Value: !Ref pSRASolutionName
       Parameters:
+        pDelegatedAdminAccountId: !Ref pAuditAccountId
         pLambdaLogGroupKmsKey: ''
         pRegisterDelegatedAdminLambdaRoleName: sra-config-conformance-pack-register-delegated-admin-lambda
         pRegisterDelegatedAdminLambdaFunctionName: sra-config-conformance-pack-register-delegated-admin
         pServicePrincipalList: config-multiaccountsetup.amazonaws.com
+        pSRAStagingS3BucketName: !Ref pSRAStagingS3BucketName
 
   rConfigConformancePackOrgDeliveryBucketStackSet:
     Type: AWS::CloudFormation::StackSet
@@ -198,13 +200,13 @@ Resources:
       Description: !If
         - cRegisterDelegatedAdmin
         - !Sub [
-            "${pSRASolutionVersion} - This template creates an AWS Organizations Config Conformance Pack in the Control Tower Audit account. - 'config_conformance_pack_org'
-            solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples. Delegated Admin Solution -
-            ${SolutionName}",
+            "${pSRASolutionVersion} - This template creates an AWS Organizations Config Conformance Pack in the Control Tower Audit account. -
+            'config_conformance_pack_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples. Delegated
+            Admin Solution - ${SolutionName}",
             SolutionName: !GetAtt rCommonRegisterDelegatedAdminStack.Outputs.oSRASolutionName,
           ]
-        - !Sub ${pSRASolutionVersion} - This template creates an AWS Organizations Config Conformance Pack in the Control Tower Audit account. - 'config_conformance_pack_org'
-          solution in repo, https://github.com/aws-samples/aws-security-reference-architecture-examples.
+        - !Sub ${pSRASolutionVersion} - This template creates an AWS Organizations Config Conformance Pack in the Control Tower Audit account. -
+          'config_conformance_pack_org' solution in repo, https://github.com/aws-samples/aws-security-reference-architecture-examples.
       ExecutionRoleName: AWSControlTowerExecution
       ManagedExecution:
         Active: true
@@ -213,8 +215,6 @@ Resources:
         MaxConcurrentPercentage: 100
         RegionConcurrencyType: PARALLEL
       PermissionModel: SELF_MANAGED
-      Capabilities:
-        - CAPABILITY_NAMED_IAM
       StackInstancesGroup:
         - DeploymentTargets:
             Accounts:
@@ -230,7 +230,7 @@ Resources:
         - ParameterKey: pConformancePackTemplateName
           ParameterValue: !Ref pConformancePackTemplateName
         - ParameterKey: pDeliveryS3BucketName
-          ParameterValue: !Sub awsconfigconforms-sra-${pAuditAccountId}-${AWS::Region}
+          ParameterValue: !Sub awsconfigconforms-sra-${pLogArchiveAccountId}-${AWS::Region}
         - ParameterKey: pDeliveryS3KeyPrefix
           ParameterValue: !Ref pDeliveryS3KeyPrefix
         - ParameterKey: pExcludedAccounts


### PR DESCRIPTION
# Changes

- Added missing parameters to the sra-config-conformance-pack-org files for non-ssm deployments
- Added missing output parameter to the sra-common-register-delegated-administrator.yaml template

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
