### PR TITLE
Updates to support AWS Security Hub CIS AWS Foundations Benchmark v1.4.0 standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
+- [2022-12-02](#2022-12-02)
 - [2022-09-15](#2022-09-15)
 - [2022-07-29](#2022-07-29)
 - [2022-07-15](#2022-07-15)
@@ -31,6 +32,12 @@
 All notable changes to this project will be documented in this file.
 
 ---
+
+## 2022-12-02
+
+### Changed<!-- omit in toc -->
+
+- Updated the [Security Hub Organization](aws_sra_examples/solutions/securityhub/securityhub_org) solution to support enabling the CIS AWS Foundations Benchmark v1.4.0 standard.
 
 ## 2022-09-15
 

--- a/aws_sra_examples/quick_setup/templates/sra-quick-setup-ssm.yaml
+++ b/aws_sra_examples/quick_setup/templates/sra-quick-setup-ssm.yaml
@@ -130,6 +130,7 @@ Metadata:
           - pDeploySecurityHubSolution
           - pDisableSecurityHub
           - pEnableCISStandard
+          - pCISStandardVersion
           - pEnablePCIStandard
           - pEnableSecurityBestPracticesStandard
           - pRegionLinkingMode
@@ -170,6 +171,8 @@ Metadata:
         default: (Optional) Billing Title
       pBucketNamePrefix:
         default: S3 Log Bucket Name Prefix
+      pCISStandardVersion:
+        default: CIS Standard Version
       pCloudTrailLogGroupKmsKey:
         default: (Optional) CloudTrail CloudWatch Logs KMS Key
       pCloudTrailLogGroupRetention:
@@ -397,6 +400,11 @@ Parameters:
       S3 bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
     Default: sra-org-trail-logs
     Description: S3 bucket prefix. The account and region will get added to the end. e.g. bucket-prefix-123456789012-us-east-1
+    Type: String
+  pCISStandardVersion:
+    AllowedValues: [1.2.0, 1.4.0]
+    Default: 1.4.0
+    Description: CIS Standard Version
     Type: String
   pCloudTrailLogGroupKmsKey:
     AllowedPattern: ^$|^arn:(aws[a-zA-Z-]*){1}:kms:[a-z0-9-]+:\d{12}:key\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$
@@ -1229,6 +1237,7 @@ Resources:
       TemplateURL: !Sub https://${pSRAStagingS3BucketName}.s3.${AWS::Region}.${AWS::URLSuffix}/sra-securityhub-org/templates/sra-securityhub-org-main-ssm.yaml
       Parameters:
         # pAuditAccountId: !Ref pAuditAccountId
+        pCISStandardVersion: !Ref pCISStandardVersion
         pComplianceFrequency: !Ref pComplianceFrequency
         # pControlTowerRegionsOnly: !Ref pControlTowerRegionsOnly
         pCreateLambdaLogGroup: !If [cCreateLambdaLogGroup, true, false]

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/README.md
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/README.md
@@ -177,6 +177,8 @@ In the `management account (home region)`, launch an AWS CloudFormation **Stack*
 
 #### Solution Update Instructions<!-- omit in toc -->
 
+**Note:** To update the standard version, disable the standard before updating to the next version.
+
 1. [Download and Stage the SRA Solutions](../../../docs/DOWNLOAD-AND-STAGE-SOLUTIONS.md). **Note:** Get the latest code and run the staging script.
 2. Update the existing CloudFormation Stack or CFCT configuration. **Note:** Make sure to update the `SRA Solution Version` parameter and any new added parameters.
 

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/README.md
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/README.md
@@ -177,7 +177,7 @@ In the `management account (home region)`, launch an AWS CloudFormation **Stack*
 
 #### Solution Update Instructions<!-- omit in toc -->
 
-**Note:** To update the standard version, disable the standard before updating to the next version.
+**Note:** To update the standard version (e.g. CIS 1.2.0 to CIS 1.4.0), first disable the standard and then enable with the new version.
 
 1. [Download and Stage the SRA Solutions](../../../docs/DOWNLOAD-AND-STAGE-SOLUTIONS.md). **Note:** Get the latest code and run the staging script.
 2. Update the existing CloudFormation Stack or CFCT configuration. **Note:** Make sure to update the `SRA Solution Version` parameter and any new added parameters.

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/customizations_for_aws_control_tower/manifest-v2.yaml
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/customizations_for_aws_control_tower/manifest-v2.yaml
@@ -11,6 +11,8 @@ resources:
   - name: sra-securityhub-org-main-ssm
     resource_file: templates/sra-securityhub-org-main-ssm.yaml
     parameters:
+      - parameter_key: pCISStandardVersion
+        parameter_value: '1.4.0'
       - parameter_key: pComplianceFrequency
         parameter_value: 7
       - parameter_key: pControlTowerRegionsOnly
@@ -47,6 +49,8 @@ resources:
   #   parameters:
   #     - parameter_key: pAuditAccountId
   #       parameter_value: ''
+  #     - parameter_key: pCISStandardVersion
+  #       parameter_value: '1.4.0'
   #     - parameter_key: pComplianceFrequency
   #       parameter_value: 7
   #     - parameter_key: pControlTowerRegionsOnly

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/customizations_for_aws_control_tower/parameters/sra-securityhub-org-main-ssm.json
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/customizations_for_aws_control_tower/parameters/sra-securityhub-org-main-ssm.json
@@ -1,5 +1,9 @@
 [
     {
+        "ParameterKey": "pCISStandardVersion",
+        "ParameterValue": "1.4.0"
+    },
+    {
         "ParameterKey": "pComplianceFrequency",
         "ParameterValue": "7"
     },

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/customizations_for_aws_control_tower/parameters/sra-securityhub-org-main.json
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/customizations_for_aws_control_tower/parameters/sra-securityhub-org-main.json
@@ -4,6 +4,10 @@
         "ParameterValue": ""
     },
     {
+        "ParameterKey": "pCISStandardVersion",
+        "ParameterValue": "1.4.0"
+    },
+    {
         "ParameterKey": "pComplianceFrequency",
         "ParameterValue": "7"
     },

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/lambda/src/securityhub.py
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/lambda/src/securityhub.py
@@ -1,6 +1,6 @@
 """This script performs operations to enable, configure, and disable SecurityHub.
 
-Version: 1.1
+Version: 1.2
 
 'securityhub_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
 
@@ -353,11 +353,15 @@ def get_standard_dictionary(account_id: str, region: str, aws_partition: str, sb
     Returns:
         Standard ARN Dictionary
     """
+    cis_standard_arn: str = f"arn:{aws_partition}:securityhub:::ruleset/cis-aws-foundations-benchmark/v/{cis_version}"
+    if cis_version != "1.2.0":
+        cis_standard_arn = f"arn:{aws_partition}:securityhub:{region}::standards/cis-aws-foundations-benchmark/v/{cis_version}"
+
     return {
         "cis": {
             "name": "CIS AWS Foundations Benchmark Security Standard",
             "enabled": False,
-            "standard_arn": f"arn:{aws_partition}:securityhub:::ruleset/cis-aws-foundations-benchmark/v/{cis_version}",
+            "standard_arn": cis_standard_arn,
             "subscription_arn": f"arn:{aws_partition}:securityhub:{region}:{account_id}:subscription/cis-aws-foundations-benchmark/v/{cis_version}",
         },
         "pci": {

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-configuration.yaml
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-configuration.yaml
@@ -9,7 +9,7 @@ Description:
 
 Metadata:
   SRA:
-    Version: 1.2
+    Version: 1.3
     Order: 3
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -112,8 +112,8 @@ Metadata:
 
 Parameters:
   pCISStandardVersion:
-    AllowedValues: [1.2.0]
-    Default: 1.2.0
+    AllowedValues: [1.2.0, 1.4.0]
+    Default: 1.4.0
     Description: CIS Standard Version
     Type: String
   pComplianceFrequency:

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-main-ssm.yaml
@@ -9,7 +9,7 @@ Description:
 
 Metadata:
   SRA:
-    Version: 1.4
+    Version: 1.5
     Entry: Parameters for deploying the solution resolving SSM parameters
     Order: 1
   AWS::CloudFormation::Interface:
@@ -32,6 +32,7 @@ Metadata:
           - pDisableSecurityHub
           - pEnableSecurityBestPracticesStandard
           - pEnableCISStandard
+          - pCISStandardVersion
           - pEnablePCIStandard
           - pRegionLinkingMode
           - pControlTowerRegionsOnly
@@ -53,6 +54,8 @@ Metadata:
     ParameterLabels:
       pAuditAccountId:
         default: Audit Account ID
+      pCISStandardVersion:
+        default: CIS Standard Version
       pComplianceFrequency:
         default: Frequency to Check for Organizational Compliance
       pControlTowerRegionsOnly:
@@ -100,6 +103,11 @@ Parameters:
     Default: /sra/control-tower/audit-account-id
     Description: SSM Parameter for AWS Account ID of the Control Tower account to delegate administration.
     Type: AWS::SSM::Parameter::Value<String>
+  pCISStandardVersion:
+    AllowedValues: [1.2.0, 1.4.0]
+    Default: 1.4.0
+    Description: CIS Standard Version
+    Type: String
   pComplianceFrequency:
     ConstraintDescription: Compliance Frequency must be a number between 1 and 30, inclusive.
     Default: 7
@@ -213,8 +221,8 @@ Parameters:
       name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
     Type: AWS::SSM::Parameter::Value<String>
   pSRASolutionVersion:
-    AllowedValues: [v1.4]
-    Default: v1.4
+    AllowedValues: [v1.5]
+    Default: v1.5
     Description: The SRA solution version. Used to trigger updates on the nested StackSets.
     Type: String
 
@@ -279,6 +287,7 @@ Resources:
     Properties:
       TemplateURL: !Sub https://${pSRAStagingS3BucketName}.s3.${AWS::Region}.${AWS::URLSuffix}/${pSRASolutionName}/templates/sra-securityhub-org-configuration.yaml
       Parameters:
+        pCISStandardVersion: !Ref pCISStandardVersion
         pComplianceFrequency: !Ref pComplianceFrequency
         pControlTowerRegionsOnly: !Ref pControlTowerRegionsOnly
         pCreateLambdaLogGroup: !Ref pCreateLambdaLogGroup

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-main.yaml
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-main.yaml
@@ -9,7 +9,7 @@ Description:
 
 Metadata:
   SRA:
-    Version: 1.4
+    Version: 1.5
     Entry: Parameters for deploying the solution
     Order: 1
   AWS::CloudFormation::Interface:
@@ -31,6 +31,7 @@ Metadata:
           - pDisableSecurityHub
           - pEnableSecurityBestPracticesStandard
           - pEnableCISStandard
+          - pCISStandardVersion
           - pEnablePCIStandard
           - pRegionLinkingMode
           - pControlTowerRegionsOnly
@@ -52,6 +53,8 @@ Metadata:
     ParameterLabels:
       pAuditAccountId:
         default: Audit Account ID
+      pCISStandardVersion:
+        default: CIS Standard Version
       pComplianceFrequency:
         default: Frequency to Check for Organizational Compliance
       pControlTowerRegionsOnly:
@@ -95,6 +98,11 @@ Parameters:
     ConstraintDescription:
       Must be alphanumeric or special characters [., _, -]. In addition, the slash character ( / ) used to delineate hierarchies in parameter names.
     Description: AWS Account ID of the Control Tower Audit account.
+    Type: String
+  pCISStandardVersion:
+    AllowedValues: [1.2.0, 1.4.0]
+    Default: 1.4.0
+    Description: CIS Standard Version
     Type: String
   pComplianceFrequency:
     ConstraintDescription: Compliance Frequency must be a number between 1 and 30, inclusive.
@@ -199,8 +207,8 @@ Parameters:
       numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
     Type: String
   pSRASolutionVersion:
-    AllowedValues: [v1.4]
-    Default: v1.4
+    AllowedValues: [v1.5]
+    Default: v1.5
     Description: The SRA solution version. Used to trigger updates on the nested StackSets.
     Type: String
 
@@ -265,6 +273,7 @@ Resources:
     Properties:
       TemplateURL: !Sub https://${pSRAStagingS3BucketName}.s3.${AWS::Region}.${AWS::URLSuffix}/${pSRASolutionName}/templates/sra-securityhub-org-configuration.yaml
       Parameters:
+        pCISStandardVersion: !Ref pCISStandardVersion
         pComplianceFrequency: !Ref pComplianceFrequency
         pControlTowerRegionsOnly: !Ref pControlTowerRegionsOnly
         pCreateLambdaLogGroup: !Ref pCreateLambdaLogGroup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws_sra_examples"
-version = "2.1.6"
+version = "2.1.7"
 description = "AWS Security Reference Architecture Examples"
 authors = ["Amazon Web Services <no_reply@amazon.com>"]
 license = "MIT-0 License"


### PR DESCRIPTION
Updated the [Security Hub Organization](aws_sra_examples/solutions/securityhub/securityhub_org) solution to support enabling the CIS AWS Foundations Benchmark v1.4.0 standard.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
