### PR TITLE
Missing Ref syntax for pCustomerControlTowerRegionsWithoutHomeRegion …

### DIFF
--- a/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-main.yaml
+++ b/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-main.yaml
@@ -266,7 +266,7 @@ Resources:
         - ParameterKey: pCustomerControlTowerRegions
           ParameterValue: !Ref pCustomerControlTowerRegions
         - ParameterKey: pCustomerControlTowerRegionsWithoutHomeRegion
-          ParameterValue: !If [cMoreThanOneControlTowerGovernedRegion, !Split [',', pCustomerControlTowerRegionsWithoutHomeRegion], 'NONE']
+          ParameterValue: !If [cMoreThanOneControlTowerGovernedRegion, !Split [',', !Ref pCustomerControlTowerRegionsWithoutHomeRegion], 'NONE']
         - ParameterKey: pEnabledRegions
           ParameterValue: !Ref pEnabledRegions
         - ParameterKey: pEnabledRegionsWithoutHomeRegion
@@ -311,7 +311,7 @@ Resources:
         - DeploymentTargets:
             Accounts:
               - !Ref AWS::AccountId
-          Regions: !Split [',', pCustomerControlTowerRegionsWithoutHomeRegion]
+          Regions: !Split [',', !Ref pCustomerControlTowerRegionsWithoutHomeRegion]
       TemplateURL: !Sub
         - https://${SRAStagingS3BucketName}.s3.${AWS::Region}.${AWS::URLSuffix}/${pSRASolutionName}/templates/sra-common-prerequisites-staging-s3-bucket.yaml
         - SRAStagingS3BucketName: !Sub ${pSRAStagingS3BucketNamePrefix}-${AWS::AccountId}-${AWS::Region}


### PR DESCRIPTION
Lines 269 and 314 of the [sra-common-prerequisites-main.yaml](https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/main/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-main.yaml) file had references to variables, but are not using the !Ref syntax to pull the variable value. This caused an errors as it was trying to use the variable name. 

This PR has the changes for those 2 lines, which allows the template to work in a live environment. 

Fixes #121  

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
