### PR TITLE
Update customizations-for-aws-control-tower.template

### DIFF
--- a/aws_sra_examples/solutions/common/common_cfct_setup/templates/customizations-for-aws-control-tower.template
+++ b/aws_sra_examples/solutions/common/common_cfct_setup/templates/customizations-for-aws-control-tower.template
@@ -260,7 +260,6 @@ Resources:
           - id: CKV_AWS_18
             comment: S3 access logging is not enabled.
     Properties:
-      AccessControl: LogDeliveryWrite
       VersioningConfiguration:
         Status: Enabled
       BucketEncryption:


### PR DESCRIPTION
https://w.amazon.com/bin/view/S3/Teams/S3Bauhaus/S3UserSecurityRuntime/S3SentinelBPANoACLByDefaultRunbook#HEnablingServerAccessLogging

https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/

<!-- markdownlint-disable MD041 -->
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1], use the [General Contributing Guidance] checklist,
and follow the pull-request checklist.

[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
[2]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
