### PR TITLE
Updated Config Management Account solution to make AWS Control Tower optional

### DIFF
--- a/aws_sra_examples/solutions/config/config_management_account/README.md
+++ b/aws_sra_examples/solutions/config/config_management_account/README.md
@@ -74,10 +74,10 @@ accounts/regions.
 
 ---
 
-### 2.0 Audit Account<!-- omit in toc -->
+### 2.0 Audit Account (Security Tooling)<!-- omit in toc -->
 
-The example solutions use `Audit Account` instead of `Security Tooling Account` to align with the default account name used within the AWS Control Tower setup process for the Security Account. The Account ID for the `Audit Account` SSM parameter is
-populated from the `SecurityAccountId` parameter within the `AWSControlTowerBP-BASELINE-CONFIG` StackSet.
+The example solutions use `Audit Account` instead of `Security Tooling Account` to align with the default account name used within the AWS Control Tower setup process for the Security Account. The Account ID for the `Audit Account`  can be determined from the `SecurityAccountId` parameter within the `AWSControlTowerBP-BASELINE-CONFIG` StackSet in AWS Control Tower environments, but is specified manually in other environments, and then stored in an SSM parameter (this is all done in the common prerequisites solution).
+
 
 #### 2.1 AWS Config Aggregator<!-- omit in toc -->
 

--- a/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account-main-ssm.yaml
+++ b/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account-main-ssm.yaml
@@ -26,6 +26,11 @@ Metadata:
           - pOrganizationId
           - pHomeRegion
       - Label:
+          default: IAM Properties
+        Parameters:
+          - pStackSetAdminRole
+          - pStackExecutionRole
+      - Label:
           default: Config Recorder Properties
         Parameters:
           - pConfigRegionsToEnable
@@ -45,6 +50,10 @@ Metadata:
           - pLambdaLogGroupKmsKey
           - pLambdaLogLevel
     ParameterLabels:
+      pStackSetAdminRole:
+        default: Stack Set Role
+      pStackExecutionRole:
+        default: Stack execution role
       pAllSupported:
         default: All Supported
       pAuditAccountId:
@@ -81,6 +90,16 @@ Metadata:
         default: SRA Staging S3 Bucket Name
 
 Parameters:
+  pStackSetAdminRole:
+    AllowedValues: [sra-stackset]
+    Default: sra-stackset
+    Description: The administration role name that is used in the stackset.
+    Type: String
+  pStackExecutionRole:
+    AllowedValues: [sra-execution]
+    Default: sra-execution
+    Description: The execution role name that is used in the stack.
+    Type: String
   pAllSupported:
     AllowedValues: ['true', 'false']
     Default: 'true'
@@ -214,10 +233,10 @@ Resources:
     Type: AWS::CloudFormation::StackSet
     Properties:
       StackSetName: sra-config-management-account
-      AdministrationRoleARN: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/AWSControlTowerStackSetRole
+      AdministrationRoleARN: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${pStackSetAdminRole}
       CallAs: SELF
       Description: !Sub ${pSRASolutionVersion} - Enables AWS Config in the Control Tower Management account.
-      ExecutionRoleName: AWSControlTowerExecution
+      ExecutionRoleName: !Ref pStackExecutionRole
       ManagedExecution:
         Active: true
       OperationPreferences:

--- a/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account-main.yaml
+++ b/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account-main.yaml
@@ -25,6 +25,11 @@ Metadata:
           - pOrganizationId
           - pHomeRegion
       - Label:
+          default: IAM Properties
+        Parameters:
+          - pStackSetAdminRole
+          - pStackExecutionRole
+      - Label:
           default: Config Recorder Properties
         Parameters:
           - pConfigRegionsToEnable
@@ -44,6 +49,10 @@ Metadata:
           - pLambdaLogGroupKmsKey
           - pLambdaLogLevel
     ParameterLabels:
+      pStackSetAdminRole:
+        default: Stack Set Role
+      pStackExecutionRole:
+        default: Stack execution role
       pAllSupported:
         default: All Supported
       pAuditAccountId:
@@ -80,6 +89,16 @@ Metadata:
         default: SRA Staging S3 Bucket Name
 
 Parameters:
+  pStackSetAdminRole:
+    AllowedValues: [sra-stackset]
+    Default: sra-stackset
+    Description: The administration role name that is used in the stackset.
+    Type: String
+  pStackExecutionRole:
+    AllowedValues: [sra-execution]
+    Default: sra-execution
+    Description: The execution role name that is used in the stack.
+    Type: String
   pAllSupported:
     AllowedValues: ['true', 'false']
     Default: 'true'
@@ -204,10 +223,10 @@ Resources:
     Type: AWS::CloudFormation::StackSet
     Properties:
       StackSetName: sra-config-management-account
-      AdministrationRoleARN: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/AWSControlTowerStackSetRole
+      AdministrationRoleARN: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${pStackSetAdminRole}
       CallAs: SELF
       Description: !Sub ${pSRASolutionVersion} - Enables AWS Config in the Control Tower Management account.
-      ExecutionRoleName: AWSControlTowerExecution
+      ExecutionRoleName: !Ref pStackExecutionRole
       ManagedExecution:
         Active: true
       OperationPreferences:


### PR DESCRIPTION
Updated Config Management Account solution to make AWS Control Tower optional

<!-- markdownlint-disable MD041 -->
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1], use the [General Contributing Guidance] checklist,
and follow the pull-request checklist.

[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
[2]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
