### PR TITLE
Fixed iam max password age regex

### DIFF
--- a/aws_sra_examples/solutions/iam/iam_password_policy/lambda/src/app.py
+++ b/aws_sra_examples/solutions/iam/iam_password_policy/lambda/src/app.py
@@ -86,7 +86,9 @@ def get_validated_parameters(event: CloudFormationCustomResourceEvent) -> dict:
 
     true_false_pattern = r"^true|false$"
 
-    parameter_pattern_validator("MAX_PASSWORD_AGE", params.get("MAX_PASSWORD_AGE", ""), pattern=r"^[0-9]$|^[0-9][0-9]$|^[0-9][0-2][0-8]$")
+    parameter_pattern_validator(
+        "MAX_PASSWORD_AGE", params.get("MAX_PASSWORD_AGE", ""), pattern=r"^[1-9]$|^[0-9][0-9]$|^[0-9][0-9][0-9]$|^[0-1][0]([0-8][0-9]|[9][0-5])$"
+    )
     parameter_pattern_validator(
         "MINIMUM_PASSWORD_LENGTH", params.get("MINIMUM_PASSWORD_LENGTH", ""), pattern=r"^[6-9]$|^[0-9][0-9]$|^[0-9][0-2][0-8]$"
     )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1], use the [General Contributing Guidance] checklist,
and follow the pull-request checklist.

[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
[2]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
-->

Fixes #131 

Fixed the MAX_PASSWORD_AGE parameter regex for the IAM Password Policy to reflect an acceptable range of 1-1095


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
