### PR TITLE
deploy sra-firewall-manager-org-waf-policy stackset in us-east-1

### DIFF
--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-main-ssm.yaml
@@ -262,7 +262,7 @@ Resources:
             Accounts:
               - !Ref pDelegatedAdminAccountId
           Regions:
-            - !Ref AWS::Region
+            - us-east-1
       TemplateURL: !Sub https://${pSRAStagingS3BucketName}.s3.${AWS::Region}.${AWS::URLSuffix}/${pSRASolutionName}/templates/sra-firewall-manager-org-waf-policy.yaml
       Tags:
         - Key: sra-solution

--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-main.yaml
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-main.yaml
@@ -259,7 +259,7 @@ Resources:
             Accounts:
               - !Ref pDelegatedAdminAccountId
           Regions:
-            - !Ref AWS::Region
+            - us-east-1
       TemplateURL: !Sub https://${pSRAStagingS3BucketName}.s3.${AWS::Region}.${AWS::URLSuffix}/${pSRASolutionName}/templates/sra-firewall-manager-org-waf-policy.yaml
       Tags:
         - Key: sra-solution


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

The Firewall Manager solution includes CloudFormation template code that will create WAF rules compatible with CloudFront (the `sra-fms-cloud-front-default-policy` policy). That template resource is bound by a condition that it only deploy in the `us-east-1` region, but if your Organization's home region is not there, the template will never deploy your CloudFront policy. This PR changes the stackset to deploy the WAF rules to `us-east-1` regardless of your org's default home region.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
