### PR TITLE
Fix manifest.yaml  - Parameter pNISTStandardVersion was invalid

### DIFF
--- a/aws_sra_examples/easy_setup/customizations_for_aws_control_tower/manifest.yaml
+++ b/aws_sra_examples/easy_setup/customizations_for_aws_control_tower/manifest.yaml
@@ -232,7 +232,7 @@ resources:
       - parameter_key: pEnableNISTStandard
         parameter_value: 'false'
       - parameter_key: pNISTStandardVersion
-        parameter_value: 'false'
+        parameter_value: '5.0.0'
       - parameter_key: pRegionLinkingMode
         parameter_value: 'SPECIFIED_REGIONS'
 


### PR DESCRIPTION
With the current version of the manifest.yaml appears the following error: 
`"Parameter 'pNISTStandardVersion' must be one of AllowedValues"`

The default value is "false" and the AllowedValues: [5.0.0]

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
