### PR TITLE
Exclude suspended accounts for terraform deployment

### DIFF
--- a/aws_sra_examples/terraform/solutions/terraform_stack.py
+++ b/aws_sra_examples/terraform/solutions/terraform_stack.py
@@ -68,7 +68,12 @@ def get_accounts() -> list:
     organizations = boto3.client("organizations")
     paginator = organizations.get_paginator("list_accounts")
 
-    accounts = [account["Id"] for page in paginator.paginate() for account in page["Accounts"]]
+    accounts = []
+    for page in paginator.paginate():
+        for account in page["Accounts"]:
+            if account["Status"] == "ACTIVE":
+                accounts.append(account["Id"])
+
     audit_account = get_audit_account()
 
     # audit account needs to go last


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1], use the [General Contributing Guidance] checklist,
and follow the pull-request checklist.

[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
[2]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
-->

Fixes #218 
Terraform_stack.py fails setting up workspace on suspended AWS accounts
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
