### PR TITLE
Stage/Upload Lambda Layer when --solution_directory argument provided

### DIFF
--- a/aws_sra_examples/docs/CFCT-DEPLOYMENT-INSTRUCTIONS.md
+++ b/aws_sra_examples/docs/CFCT-DEPLOYMENT-INSTRUCTIONS.md
@@ -4,15 +4,27 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-
 
 ---
 
+CfCT is a deployment mechanism that for SRA solutions within Control Tower enabled AWS environments.
+The requisite [SRA solution configuration files](https://github.com/boueya/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions) are stored in either CodeCommit or S3 and programmatically configured in AWS with a CodePipeline. Whether you're using the sra-easy-setup deployment method or deploying SRA controls ADHOC, the CfCT deployment mechanism makes managing and customizing SRA solutions easier.
+
+
 ## Table of Contents<!-- omit in toc -->
 
 - [Prerequisites](#prerequisites)
+  - [Deploy Control Tower](#deploy-control-tower)
   - [Create the AWSControlTowerExecution IAM Role](#create-the-awscontroltowerexecution-iam-role)
   - [Deploy Customizations for AWS Control Tower (CFCT) Solution](#deploy-customizations-for-aws-control-tower-cfct-solution)
   - [AWS CodeCommit Repo](#aws-codecommit-repo)
+  - [AWS S3 Repo](#aws-s3-repo)
+  - [Configure SRA Deployment Repo](#configue-your-sra-deployment-repo)
 - [References](#references)
 
+
 ## Prerequisites
+
+### Deploy Control Tower
+
+- These customizations act on existing Control Tower deployments. If you do not have Control Tower deployed into your environment, please do so through the AWS console. For more details on Control Tower and Landing Zone deployments, see the [userguide](https://docs.aws.amazon.com/controltower/latest/userguide/quick-start.html).
 
 ### Create the AWSControlTowerExecution IAM Role
 
@@ -27,18 +39,31 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-
     <!-- markdownlint-disable-next-line MD034 -->
     - `Amazon S3 URL` = https://s3.amazonaws.com/solutions-reference/customizations-for-aws-control-tower/latest/custom-control-tower-initiation.template
     - `Stack name` = custom-control-tower-initiation
-    - `AWS CodePipeline Source` = AWS CodeCommit
+    - `AWS CodePipeline Source` = AWS CodeCommit | S3
     - `Failure Tolerance Percentage` = 0
     - Acknowledge that AWS CloudFormation might create IAM resources with custom names
 
 Note: Version 2 or higher of CfCT is expected.
 
 ### AWS CodeCommit Repo
+*Note: AWS CodeCommit is being deprecated and cannot be deployed to new environments, unless that environment is a part of an AWS Organization with an account that already has CodeCommit deployed. Please see [AWS S3 Repo](#aws-s3-repo) for new AWS Accounts.*
+
+Create a CodeCommit repo for SRA customization [configuration files](#deployment-instructions).
 
 1. On the local machine install [git](https://git-scm.com/downloads) and [git-remote-codecommit](https://docs.aws.amazon.com/codecommit/latest/userguide/how-to-connect.html).
 2. Clone the AWS CodeCommit repository via `git clone codecommit::<HOME REGION>://custom-control-tower-configuration custom-control-tower-configuration`
 
+### AWS S3 Repo
+
+Create a CodeCommit repo for SRA cusotmization [configuration files](#deployment-instructions).
+
+- By default, the CodePipeline deployed from the custom-control-tower-initiation CloudFormation will use the `custom-control-tower-configuration-<< ACCOUNT NAME >>-<< REGION NAME >>` S3 bucket as a Source repo. Additionally, it will look for the `custom-control-tower-configuration.zip` file. The pipeline will fail without it. We have provided users with an example `_custom-control-tower-configuration.zip` file in S3 with an example repo for convenience.
+
+- If you would like to change the S3 bucket Source for the CodePipeline, you will need to navigate to the CodePipeline within the AWS console, edit the Source stage for the CodePipeline and update the Bucket name value. Users can also modify the S3 object key value if the ZIP filename differs from default.
+
+
 ## Deployment Instructions<!-- omit in toc -->
+*Note: these instructions assume version 2 or higher of the CfCT solution has been installed.*  
 
 1. Determine which version of the [Customizations for AWS Control Tower](https://aws.amazon.com/solutions/implementations/customizations-for-aws-control-tower/) solution you have deployed:
    1. Within the `management account (home region)` find the **CloudFormation Stack** for the Customizations for Control Tower (e.g. `custom-control-tower-initiation`)
@@ -48,18 +73,59 @@ Note: Version 2 or higher of CfCT is expected.
       2. Version 2 = v2.x.x = manifest.yaml version 2021-03-15
 2. If version 2 is installed, continue to the deployment instructions below.  If not, you will need to update your version of CfCT.
 
-#### Deployment Instructions<!-- omit in toc -->
 
-Note: these instructions assume version 2 or higher of the CfCT solution has been installed.
+##### Configue Your SRA Deployment Repo
 
-1. Copy the files to the Customizations for AWS Control Tower configuration `custom-control-tower-configuration`
-   - policies [optional]
-     - service control policies files (\*.json)
-   - templates [**required**]
-     - Copy the template files from the `templates` folder that are referenced in the `manifest.yaml`
-2. Update the manifest.yaml file with the `parameters`, `organizational unit names`, `account names` and `SSM parameters` for the target environment
-   - *Be sure to update `deployment_targets` `accounts` with your management account information*
-3. Deploy the Customizations for AWS Control Tower configuration by pushing the code to the `AWS CodeCommit` repository or uploading to the `AWS S3 Bucket`
+SRA Customizations with CfCT are deployed via a CodePipeline from either a CodeCommit or S3 source. 
+Here's an example of an repo for sra-easy-deploy.yaml deployment with controls/parameters for GuardDuty.
+
+> ├── manifest.yaml  
+> |  
+> ├── templates  
+> │   └── sra-easy-setup.yaml  
+> |  
+> ├── parameters  
+> │   └── sra-guardduty-org-main-ssm.json  
+> |  
+> ├── policies  
+
+
+###### manifest.yaml file [**required**]
+
+The manifest file will contain all the high level SRA controls that will be deployed to your environment.
+An example manifest file for [sra-easy-setup.yaml](https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/main/aws_sra_examples/easy_setup/customizations_for_aws_control_tower/manifest.yaml)
+
+   - Define all `parameters`, `organizational unit names`, `account names` and `SSM parameters` necessary for the SRA controls that you want to enable and configure here.
+
+   - If you are using a non-standard file structure in your Repo, as outlined above, the [*resource_file* key](https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/main/aws_sra_examples/easy_setup/customizations_for_aws_control_tower/manifest.yaml#L13C5-L13C49) value in your manifest file must reflect the path to your template.
+
+   - Be sure to update the [*accounts* key](https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/main/aws_sra_examples/easy_setup/customizations_for_aws_control_tower/manifest.yaml#L310) to reflect your Management Account name.
+   
+###### templates [**required**]
+
+The templates directory will contain the actual CloudFormation files that are defined within the manifest file.
+We use the sra-easy-setup deployment method as an example for the manifest above, [here's](https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/main/aws_sra_examples/easy_setup/templates/sra-easy-setup.yaml) what the template file looks like.
+
+You can also deploy SRA solutions ADHOC, without the sra-easy-setup, by including their corresponding manifest CFN template entry under the resources list for your manifest.yaml file. Exmaples of manifest files for supported solutions can be found within the `aws_sra_examples` repo [aws_sra_examples/solutions/<< SOLUTION NAME >>/customizations_for_aws_control_tower/manifest.yaml](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions).
+
+   - You shouldn't need to modify much in this template file as all SRA controls and parameters are defined in the manifest and files under the parameters directory, respectively.
+
+###### policies [optional] 
+
+Service control policy JSON files go here. The files under the Policies directory will depend on what SRA controls that you're deploying to your environment. Not all SRA controls will require policies defined here.
+
+###### parameters [optional]
+
+Service control parameter JSON files go here. The files under the Parameters directory will depend on what SRA controls that you're deploying to your environment. Not all SRA controls will require parameters defined here.
+
+Above, we used the [sra-guardduty-org-main-ssm.json](https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/main/aws_sra_examples/solutions/guardduty/guardduty_org/customizations_for_aws_control_tower/parameters/sra-guardduty-org-main-ssm.json) parameters file as an example for our sra-easy-setup deploying GuardDuty controls in AWS. 
+
+You can find examples of parameter files for each security solution that we support within the `aws_sra_examples` repo [aws_sra_examples/solutions/<< SOLUTION NAME >>/customizations_for_aws_control_tower/parameters/](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions).
+
+
+##### Push To CodeCommit or S3
+*Note: If you are using S3, the files above will need to be ZIPPED up and named `custom-control-tower-configuration`.*
+
 
 ### Delete Instructions<!-- omit in toc -->
 
@@ -71,6 +137,7 @@ Note: these instructions assume version 2 or higher of the CfCT solution has bee
 3. After the pipeline completes, log into the `management account` and navigate to the `CloudFormation StackSet` page
    1. Delete the Stack Instances from the `CustomControlTower-<solution_name>*` CloudFormation StackSets
    2. After the Stack Instances are deleted, delete the `CustomControlTower-<solution_name>*` CloudFormation StackSets
+
 
 ## References
 

--- a/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account.yaml
+++ b/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account.yaml
@@ -165,7 +165,7 @@ Resources:
     Type: AWS::Config::ConfigurationRecorder
     Properties:
       Name: !Sub ${pManagedResourcePrefix}-BaselineConfigRecorder
-      RoleARN: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${pManagedResourcePrefix}-ConfigRecorderRole
+      RoleARN: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig
       RecordingGroup:
         AllSupported: !Ref pAllSupported
         IncludeGlobalResourceTypes: !If

--- a/aws_sra_examples/utils/packaging_scripts/stage_solution.sh
+++ b/aws_sra_examples/utils/packaging_scripts/stage_solution.sh
@@ -404,21 +404,31 @@ if [ "$solution_directory" != "none" ]; then
     solution_name="sra-"$(tr '_' '-' <<<"$solution_name_snake_case")
     solution_lambda_s3_prefix="$solution_name/lambda_code"
     solution_templates_s3_prefix="$solution_name/templates"
+    # added for layer code
+    solution_layer_s3_prefix="$solution_name/layer_code"
 
     package_and_stage_common_solutions
     create_solution_staging_folder "$solution_templates_s3_prefix" "$solution_lambda_s3_prefix"
+    # added for layer code
+    create_solution_staging_layer_folder "$solution_layer_s3_prefix"
 
     staging_templates_folder="$STAGING_FOLDER/$solution_templates_s3_prefix" || exit 1
     staging_lambda_folder="$STAGING_FOLDER/$solution_lambda_s3_prefix" || exit 1
+    # added for layer code
+    staging_layer_folder="$STAGING_FOLDER/$solution_layer_s3_prefix" || exit 1
     echo "------------------------------------------------------------"
     echo "-- Solution: $solution_name"
     echo "------------------------------------------------------------"
     stage_cloudformation_templates "$solution_directory" "$staging_templates_folder"
     package_and_stage_lambda_code "$solution_directory" "$staging_lambda_folder" "$solution_name"
+    # added for layer code
+    package_and_stage_layer_code "$solution_directory" "$staging_layer_folder" "$solution_name"
 
     if [ -n "$BUCKET_ACL" ]; then
         upload_cloudformation_templates "$staging_templates_folder" "$solution_templates_s3_prefix"
         upload_lambda_code "$staging_lambda_folder" "$solution_lambda_s3_prefix"
+        # added for layer code
+        upload_layer_code "$staging_layer_folder" "$solution_layer_s3_prefix"
 
         cd "$staging_lambda_folder" || exit 1
         update_lambda_functions "$solution_lambda_s3_prefix"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1], use the [General Contributing Guidance] checklist,
and follow the pull-request checklist.

[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
[2]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
-->

Added a few clarifying updates to the documentation.

----

Bug fix for: [Issue 156](https://github.com/aws-samples/aws-security-reference-architecture-examples/issues/156)

Currently, the script does not deploy a lambda code layer directory when the --solution_directory argument is passed. I've updated the logic to add this.

----

Update for: [Issue 273](https://github.com/aws-samples/aws-security-reference-architecture-examples/issues/273)

Currently, in Control Tower enabled environments, the sra-easy-setup deploys a control tower custom role for the ConfigRecorder and is picked up as a Critical finding in SecurityHub because security guidance recommends the use of a service linked role. The custom role however only has a Config managed policy applied to it. 

Because this managed policy doesn't appear to provide additional access not included in the ConfigRecorder service linked role, I've replaced the custom role with the service linked role.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
