### PR TITLE
Enable possibility to configure inspector ec2 scan mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)
+- [2024-12-18](#2024-12-18)
 - [2024-09-18](#2024-09-18)
 - [2024-08-22](#2024-08-22)
 - [2024-07-17](#2024-07-17)
@@ -57,6 +58,13 @@
 All notable changes to this project will be documented in this file.
 
 ---
+
+## 2024-12-18
+
+### Added<!-- omit in toc -->
+
+- Updated [Inspector](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/inspector/inspector_org) solution to configure ec2 scan mode
+
 ## 2024-09-18
 
 ### Added<!-- omit in toc -->
@@ -169,7 +177,7 @@ Updated [Firewall Manager](https://github.com/aws-samples/aws-security-reference
 ### Changed<!-- omit in toc -->
 
 - Added GuardDuty EKS, Malware, RDS, and Lambda protections [GuardDuty Organization](aws_sra_examples/solutions/guardduty/guardduty_org)
-- Added fix to support deploying to more than 50 accounts. https://github.com/aws-samples/aws-security-reference-architecture-examples/issues/139. UpdateMemberDetectors and CreateMembers parameters accountIds and accountDetails support a max number
+- Added fix to support deploying to more than 50 accounts. <https://github.com/aws-samples/aws-security-reference-architecture-examples/issues/139>. UpdateMemberDetectors and CreateMembers parameters accountIds and accountDetails support a max number
   of 50 items
 
 ## 2023-05-12

--- a/aws_sra_examples/easy_setup/customizations_for_aws_control_tower/manifest.yaml
+++ b/aws_sra_examples/easy_setup/customizations_for_aws_control_tower/manifest.yaml
@@ -207,6 +207,8 @@ resources:
         parameter_value: "EC2, ECR, LAMBDA, LAMBDA_CODE"
       - parameter_key: pEcrRescanDuration
         parameter_value: "LIFETIME"
+      - parameter_key: pEcrRescanDuration
+        parameter_value: "EC2_SSM_AGENT_BASED"
 
       # Macie Solution
       - parameter_key: pDisableMacie

--- a/aws_sra_examples/easy_setup/templates/sra-easy-setup.yaml
+++ b/aws_sra_examples/easy_setup/templates/sra-easy-setup.yaml
@@ -257,6 +257,7 @@ Metadata:
         Parameters:
           - pScanComponents
           - pEcrRescanDuration
+          - pEc2ScanMode
 
       - Label:
           default: Patch Manager Solution
@@ -332,6 +333,8 @@ Metadata:
         default: Comma separated list of scan components (EC2, ECR, LAMBDA, LAMBDA_CODE)
       pEcrRescanDuration:
         default: ECR Rescan Duration
+      pEc2ScanMode:
+         default: EC2 Scan Mode
       pDeployInspectorSolution:
         default: Deploy the Inspector Solution
 
@@ -797,6 +800,11 @@ Parameters:
     AllowedValues: [LIFETIME, DAYS_30, DAYS_180]
     Default: LIFETIME
     Description: ECR Rescan Duration
+    Type: String
+  pEc2ScanMode:
+    AllowedValues: [EC2_SSM_AGENT_BASED, EC2_HYBRID]
+    Default: EC2_SSM_AGENT_BASED
+    Description: EC2 Scan Mode
     Type: String
   pDeployInspectorSolution:
     AllowedValues: ["Yes", "No"]
@@ -2941,6 +2949,7 @@ Resources:
           - ","
           - !Ref pScanComponents
         pEcrRescanDuration: !Ref pEcrRescanDuration
+        pEc2ScanMode: !Ref pEc2ScanMode
         pLambdaLogGroupKmsKey: !Ref pLambdaLogGroupKmsKey
         pLambdaLogGroupRetention: !Ref pLambdaLogGroupRetention
         pLambdaLogLevel: !Ref pLambdaLogLevel

--- a/aws_sra_examples/solutions/inspector/inspector_org/README.md
+++ b/aws_sra_examples/solutions/inspector/inspector_org/README.md
@@ -91,7 +91,7 @@ The Inspector Organization solution will automate enabling Amazon Inspector by d
 
 - The python boto3 SDK lambda layer to enable capability for lambda to enable all elements of the inspector service.
 - This is downloaded during the deployment process and packaged into a layer that is used by the lambda function in this solution.
-- The inspector API available in the current lambda environment (as of 01/19/2023) is boto3-1.20.32, however, enhanced functionality of the inspector API used in this solution requires at least 1.26.18 (see references below).
+- The inspector API available in the current lambda environment (as of 01/19/2023) is boto3-1.20.32, however, enhanced functionality of the inspector API used in this solution requires at least 1.35.83 (see references below).
 - Note: Future revisions to this solution will remove this layer when boto3 is updated within the lambda environment.
 
 ---

--- a/aws_sra_examples/solutions/inspector/inspector_org/customizations_for_aws_control_tower/manifest.yaml
+++ b/aws_sra_examples/solutions/inspector/inspector_org/customizations_for_aws_control_tower/manifest.yaml
@@ -33,6 +33,8 @@ resources:
         parameter_value: EC2, ECR, LAMBDA, LAMBDA_CODE
       - parameter_key: pEcrRescanDuration
         parameter_value: 'LIFETIME'
+      - parameter_key: pEc2ScanMode
+        parameter_value: 'EC2_SSM_AGENT_BASED'
     deploy_method: stack_set
     deployment_targets:
       accounts:

--- a/aws_sra_examples/solutions/inspector/inspector_org/customizations_for_aws_control_tower/parameters/sra-inspector-org-main-ssm.json
+++ b/aws_sra_examples/solutions/inspector/inspector_org/customizations_for_aws_control_tower/parameters/sra-inspector-org-main-ssm.json
@@ -42,6 +42,10 @@
   {
     "ParameterKey": "pEcrRescanDuration",
     "ParameterValue": "LIFETIME"
+  },
+  {
+    "ParameterKey": "pEc2ScanMode",
+    "ParameterValue": "EC2_SSM_AGENT_BASED"
   }
 
 ]

--- a/aws_sra_examples/solutions/inspector/inspector_org/templates/sra-inspector-org-configuration.yaml
+++ b/aws_sra_examples/solutions/inspector/inspector_org/templates/sra-inspector-org-configuration.yaml
@@ -36,6 +36,7 @@ Metadata:
           - pEnabledRegions
           - pScanComponents
           - pEcrRescanDuration
+          - pEc2ScanMode
 
       - Label:
           default: General Lambda Function Properties
@@ -91,6 +92,8 @@ Metadata:
         default: Comma separated list of scan components (EC2, ECR, LAMBDA, LAMBDA_CODE)
       pEcrRescanDuration:
         default: ECR Rescan Duration
+      pEc2ScanMode:
+        default: EC2 Scan Mode
 
 Parameters:
   pComplianceFrequency:
@@ -203,6 +206,11 @@ Parameters:
     AllowedValues: [LIFETIME, DAYS_30, DAYS_180]
     Default: LIFETIME
     Description: ECR Rescan Duration
+    Type: String
+  pEc2ScanMode:
+    AllowedValues: [EC2_SSM_AGENT_BASED, EC2_HYBRID]
+    Default: EC2_SSM_AGENT_BASED
+    Description: EC2 Scan Mode
     Type: String
 
 Conditions:
@@ -472,6 +480,7 @@ Resources:
           - ','
           - !Ref pScanComponents
           ECR_SCAN_DURATION: !Ref pEcrRescanDuration
+          EC2_SCAN_MODE: !Ref pEc2ScanMode
       Tags:
         - Key: sra-solution
           Value: !Ref pSRASolutionName
@@ -482,7 +491,7 @@ Resources:
       Content:
         S3Bucket: !Ref pSRAStagingS3BucketName
         S3Key: !Sub ${pSRASolutionName}/layer_code/${pSRASolutionName}-layer.zip
-      Description: Boto3 version 1.26.24 layer to enable newer API of inspector2
+      Description: Boto3 version 1.35.83 layer to enable newer API of inspector2
       LayerName: !Sub ${pInspectorOrgLambdaFunctionName}-updated-boto3-layer
 
   rInspectorOrgLambdaCustomResource:
@@ -498,6 +507,7 @@ Resources:
       - ','
       - !Ref pScanComponents
       ECR_SCAN_DURATION: !Ref pEcrRescanDuration
+      EC2_SCAN_MODE: !Ref pEc2ScanMode
 
   rInspectorOrgTopic:
     Type: AWS::SNS::Topic

--- a/aws_sra_examples/solutions/inspector/inspector_org/templates/sra-inspector-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/inspector/inspector_org/templates/sra-inspector-org-main-ssm.yaml
@@ -38,6 +38,7 @@ Metadata:
           - pEnabledRegions
           - pScanComponents
           - pEcrRescanDuration
+          - pEc2ScanMode
 
       - Label:
           default: General Lambda Function Properties
@@ -92,6 +93,8 @@ Metadata:
         default: Comma separated list of scan components (EC2, ECR, LAMBDA, LAMBDA_CODE)
       pEcrRescanDuration:
         default: ECR Rescan Duration
+      pEc2ScanMode:
+        default: EC2 Scan Mode
 
 Parameters:
   pStackSetAdminRole:
@@ -211,6 +214,11 @@ Parameters:
     Default: LIFETIME
     Description: ECR Rescan Duration
     Type: String
+  pEc2ScanMode:
+    AllowedValues: [EC2_SSM_AGENT_BASED, EC2_HYBRID]
+    Default: EC2_SSM_AGENT_BASED
+    Description: EC2 Scan Mode
+    Type: String
 
 Conditions:
   cNotGlobalRegionUsEast1: !Not [!Equals [!Ref 'AWS::Region', us-east-1]]
@@ -282,6 +290,7 @@ Resources:
           - ','
           - !Ref pScanComponents
         pEcrRescanDuration: !Ref pEcrRescanDuration
+        pEc2ScanMode: !Ref pEc2ScanMode
       Tags:
         - Key: sra-solution
           Value: !Ref pSRASolutionName


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!--
Enable the possibility to configure the scan mode for EC2 in Inspector.
This feature was requested here:
https://github.com/aws-samples/aws-security-reference-architecture-examples/issues/234

Please read the [Contribution guidelines][1], use the [General Contributing Guidance] checklist,
and follow the pull-request checklist.

[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
[2]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
