### PR TITLE
Adding config recorder service-linked role.

### DIFF
--- a/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account-role.yaml
+++ b/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account-role.yaml
@@ -17,13 +17,21 @@ Metadata:
         Parameters:
           - pSRASolutionTagKey
           - pSRASolutionName
+          - pManagedResourcePrefix
     ParameterLabels:
+      pManagedResourcePrefix:
+        default: Managed Resource Prefix
       pSRASolutionName:
         default: SRA Solution Name
       pSRASolutionTagKey:
         default: SRA Solution Tag Key
 
 Parameters:
+  pManagedResourcePrefix:
+    AllowedValues: [aws-controltower]
+    Default: aws-controltower
+    Description: Prefix for the managed resources
+    Type: String
   pSRASolutionName:
     AllowedValues: [sra-config-management-account]
     Default: sra-config-management-account

--- a/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account-role.yaml
+++ b/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account-role.yaml
@@ -17,21 +17,13 @@ Metadata:
         Parameters:
           - pSRASolutionTagKey
           - pSRASolutionName
-          - pManagedResourcePrefix
     ParameterLabels:
-      pManagedResourcePrefix:
-        default: Managed Resource Prefix
       pSRASolutionName:
         default: SRA Solution Name
       pSRASolutionTagKey:
         default: SRA Solution Tag Key
 
 Parameters:
-  pManagedResourcePrefix:
-    AllowedValues: [aws-controltower]
-    Default: aws-controltower
-    Description: Prefix for the managed resources
-    Type: String
   pSRASolutionName:
     AllowedValues: [sra-config-management-account]
     Default: sra-config-management-account
@@ -44,31 +36,8 @@ Parameters:
     Type: String
 
 Resources:
-  rConfigRecorderRole:
-    Metadata:
-      cfn_nag:
-        rules_to_suppress:
-          - id: W28
-            reason: Explicit name provided
-    Type: AWS::IAM::Role
+  rConfigServiceLinkedRole:
+    Type: AWS::IAM::ServiceLinkedRole
     Properties:
-      RoleName: !Sub ${pManagedResourcePrefix}-ConfigRecorderRole
-      Description: Role for AWS Config Recorder
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action: sts:AssumeRole
-            Principal:
-              Service:
-                - config.amazonaws.com
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWS_ConfigRole
-      Tags:
-        - Key: !Ref pSRASolutionTagKey
-          Value: !Ref pSRASolutionName
-
-Outputs:
-  oConfigRecorderRoleArn:
-    Description: Config Recorder Role ARN
-    Value: !GetAtt rConfigRecorderRole.Arn
+      AWSServiceName: config.amazonaws.com
+      Description: A service-linked role for the ConfigRecorder.

--- a/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account.yaml
+++ b/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account.yaml
@@ -165,7 +165,7 @@ Resources:
     Type: AWS::Config::ConfigurationRecorder
     Properties:
       Name: !Sub ${pManagedResourcePrefix}-BaselineConfigRecorder
-      RoleARN: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${pManagedResourcePrefix}-ConfigRecorderRole
+      RoleARN: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig
       RecordingGroup:
         AllSupported: !Ref pAllSupported
         IncludeGlobalResourceTypes: !If


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1], use the [General Contributing Guidance] checklist,
and follow the pull-request checklist.

[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
[2]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
-->

Fixes #273 

Replacing Config Recorder custom role with service-linked role.
The Config Recorder custom role only had the Config managed policy applied, so I've replaced it in to align with guidance. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
