### PR TITLE
Fix to sra-easy-setup deployment method.

### DIFF
--- a/aws_sra_examples/easy_setup/templates/sra-easy-setup.yaml
+++ b/aws_sra_examples/easy_setup/templates/sra-easy-setup.yaml
@@ -2288,6 +2288,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - cloudformation:DescribeStacks
+                  - cloudformation:GetTemplateSummary
                 Resource: "*"
         - PolicyName: "IAM-Access-Policy"
           PolicyDocument:


### PR DESCRIPTION
…access policy for codebuild.

<!-- markdownlint-disable MD041 -->
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1], use the [General Contributing Guidance] checklist,
and follow the pull-request checklist.

[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
[2]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
-->

Fixes #282 

Added the ``cloudformation:GetTemplateSummary`` action to policy ``cloudformation-describe-access`` so that codebuild can get template summaries during sra-easy-setup deployments.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
