### PR TITLE
AWS Inspector - update ECR rescan settings

### DIFF
--- a/aws_sra_examples/solutions/inspector/inspector_org/lambda/src/inspector.py
+++ b/aws_sra_examples/solutions/inspector/inspector_org/lambda/src/inspector.py
@@ -421,14 +421,18 @@ def enable_inspector2_in_member_accounts(
 
 
 def set_ecr_scan_duration(
-    region: str, configuration_role_name: str, delegated_admin_account_id: str, ecr_scan_duration: Literal["DAYS_180", "DAYS_30", "LIFETIME"]
+    region: str, configuration_role_name: str,
+    delegated_admin_account_id: str,
+    ecr_pull_scan_duration: Literal["DAYS_14", "DAYS_30", "DAYS_60", "DAYS_90", "DAYS_180",  "LIFETIME"],
+    ecr_scan_duration: Literal["DAYS_14", "DAYS_30", "DAYS_60", "DAYS_90", "DAYS_180",  "LIFETIME"]
 ) -> None:
     """Set the ECR scan duration in the delegated administrator account.
 
     Args:
         configuration_role_name: configuration role name
         delegated_admin_account_id: delegated admin account id
-        ecr_scan_duration: ecr scan duration
+        ecr_pull_scan_duration: ecr scan duration (on image pull)
+        ecr_scan_duration: ecr scan duration (on image push)
         region: AWS region
 
     Returns:
@@ -439,13 +443,16 @@ def set_ecr_scan_duration(
         f"creating delegated admin session with ({configuration_role_name}) in account ({delegated_admin_account_id}) to set ecr scan duration"
     )
     inspector_delegated_admin_region_client: Inspector2Client = delegated_admin_session.client("inspector2", region)
-    LOGGER.info(f"Setting ECR scan duration in delegated admin account to {ecr_scan_duration} in {region}")
+    LOGGER.info(f"In delegated admin account, setting ECR push scan duration to {ecr_scan_duration} and ECR pull scan duration to {ecr_pull_scan_duration} in {region}")
     LOGGER.info(f"delegated admin client region: {inspector_delegated_admin_region_client.meta.region_name}")
     LOGGER.info(f"Region: {delegated_admin_session.region_name}")
     sts_client = delegated_admin_session.client("sts", region_name=region)
     LOGGER.info(f"caller identity: {sts_client.get_caller_identity()}")
     configuration_response: dict = inspector_delegated_admin_region_client.update_configuration(
-        ecrConfiguration={"rescanDuration": ecr_scan_duration}
+        ecrConfiguration={
+            "pullDateRescanDuration": ecr_pull_scan_duration
+            "rescanDuration": ecr_scan_duration
+            }
     )
     api_call_details = {"API_Call": "inspector:UpdateConfiguration", "API_Response": configuration_response}
     LOGGER.info(api_call_details)

--- a/aws_sra_examples/solutions/inspector/inspector_org/templates/sra-inspector-org-configuration.yaml
+++ b/aws_sra_examples/solutions/inspector/inspector_org/templates/sra-inspector-org-configuration.yaml
@@ -35,6 +35,7 @@ Metadata:
           - pControlTowerRegionsOnly
           - pEnabledRegions
           - pScanComponents
+          - pEcrPullRescanDuration
           - pEcrRescanDuration
 
       - Label:
@@ -89,8 +90,10 @@ Metadata:
         default: Inspector Configuration Role Name
       pScanComponents:
         default: Comma separated list of scan components (EC2, ECR, LAMBDA, LAMBDA_CODE)
+      pEcrPullRescanDuration:
+        default: ECR Rescan Duration on image pull
       pEcrRescanDuration:
-        default: ECR Rescan Duration
+        default: ECR Rescan Duration on image push
 
 Parameters:
   pComplianceFrequency:
@@ -199,10 +202,15 @@ Parameters:
     Default: EC2, ECR, LAMBDA, LAMBDA_CODE
     Description: Lambda Function Logging Level
     Type: CommaDelimitedList
-  pEcrRescanDuration:
-    AllowedValues: [LIFETIME, DAYS_30, DAYS_180]
+  pEcrPullRescanDuration:
+    AllowedValues: [LIFETIME, DAYS_14, DAYS_30, DAYS_60, DAYS_90, DAYS_180]
     Default: LIFETIME
-    Description: ECR Rescan Duration
+    Description: ECR Rescan Duration on image pull
+    Type: String
+  pEcrRescanDuration:
+    AllowedValues: [LIFETIME, DAYS_14, DAYS_30, DAYS_60, DAYS_90, DAYS_180]
+    Default: LIFETIME
+    Description: ECR Rescan Duration on image push
     Type: String
 
 Conditions:
@@ -471,6 +479,7 @@ Resources:
           SCAN_COMPONENTS: !Join 
           - ','
           - !Ref pScanComponents
+          ECR_PULL_SCAN_DURATION: !Ref pEcrPullRescanDuration
           ECR_SCAN_DURATION: !Ref pEcrRescanDuration
       Tags:
         - Key: sra-solution
@@ -497,6 +506,7 @@ Resources:
       SCAN_COMPONENTS: !Join 
       - ','
       - !Ref pScanComponents
+      ECR_PULL_SCAN_DURATION: !Ref pEcrPullRescanDuration
       ECR_SCAN_DURATION: !Ref pEcrRescanDuration
 
   rInspectorOrgTopic:

--- a/aws_sra_examples/terraform/solutions/inspector/configuration/invoke.tf
+++ b/aws_sra_examples/terraform/solutions/inspector/configuration/invoke.tf
@@ -20,6 +20,7 @@ resource "aws_lambda_invocation" "lambda_invoke" {
       "MANAGEMENT_ACCOUNT_ID" : "${local.current_account}",
       "SNS_TOPIC_ARN" : "${aws_sns_topic.inspector_org_topic.arn}",
       "SCAN_COMPONENTS" : "${var.scan_components}",
+      "ECR_PULL_SCAN_DURATION" : "${var.ecr_pull_rescan_duration}",
       "ECR_SCAN_DURATION" : "${var.ecr_rescan_duration}",
     }
   })
@@ -45,6 +46,7 @@ resource "aws_lambda_invocation" "lambda_disable_invoke" {
       "MANAGEMENT_ACCOUNT_ID" : "${local.current_account}",
       "SNS_TOPIC_ARN" : "${aws_sns_topic.inspector_org_topic.arn}",
       "SCAN_COMPONENTS" : "${var.scan_components}",
+      "ECR_SCAN_DURATION" : "${var.ecr_pull_rescan_duration}",
       "ECR_SCAN_DURATION" : "${var.ecr_rescan_duration}",
     }
   })

--- a/aws_sra_examples/terraform/solutions/inspector/configuration/main.tf
+++ b/aws_sra_examples/terraform/solutions/inspector/configuration/main.tf
@@ -395,6 +395,7 @@ resource "aws_lambda_function" "inspector_org_lambda_function" {
       MANAGEMENT_ACCOUNT_ID      = local.current_account
       SNS_TOPIC_ARN              = aws_sns_topic.inspector_org_topic.arn
       SCAN_COMPONENTS            = var.scan_components
+      ECR_PULL_SCAN_DURATION     = var.ecr_pull_rescan_duration
       ECR_SCAN_DURATION          = var.ecr_rescan_duration
     }
   }

--- a/aws_sra_examples/terraform/solutions/inspector/configuration/variables.tf
+++ b/aws_sra_examples/terraform/solutions/inspector/configuration/variables.tf
@@ -57,8 +57,14 @@ variable "inspector_configuration_role_name" {
   type        = string
 }
 
+variable "ecr_pull_rescan_duration" {
+  description = "ECR Rescan Duration on image pull"
+  type        = string
+  default     = "LIFETIME"
+}
+
 variable "ecr_rescan_duration" {
-  description = "ECR Rescan Duration"
+  description = "ECR Rescan Duration on image push"
   type        = string
   default     = "LIFETIME"
 }


### PR DESCRIPTION
This fixes https://github.com/aws-samples/aws-security-reference-architecture-examples/issues/300.

This updates the code so that it allows setting the ECR image pull and push settings separately.  Additionally, it updates the code to allow setting the scan settings to the other available durations.

<!-- markdownlint-disable MD041 -->
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1], use the [General Contributing Guidance] checklist,
and follow the pull-request checklist.

[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
[2]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
