### PR TITLE
Enable inspector in mgmt account without error

### DIFF
--- a/aws_sra_examples/solutions/inspector/inspector_org/lambda/src/inspector.py
+++ b/aws_sra_examples/solutions/inspector/inspector_org/lambda/src/inspector.py
@@ -131,6 +131,14 @@ def lookup_associated_accounts(inspector2_client: Inspector2Client, account_id: 
         response = inspector2_client.get_member(accountId=account_id)
     except inspector2_client.exceptions.ResourceNotFoundException:
         return False
+    except inspector2_client.exceptions.InternalServerException as e:
+        error_message = e.response["Error"]["Message"]
+        if "The request is rejected because the given account ID is not an associated member of the current account." in error_message: 
+            associate_account(inspector2_client, account_id)
+            return True
+        else:
+            LOGGER.error(f"Internal server error. {e.response['Error']['Message']}")
+            raise
     except Exception as e:
         LOGGER.error(f"Failed to get inspector members. {e}")
         raise


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!--
Enabling inspector fails on the mgmt account and lambda _sra-inspector-org_ exits prematurely.
This PR fixes that.
-->

Fixes # 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
