### PR TITLE
Add exception handling for InternalServerException in lookup_associated_accounts

### DIFF
--- a/aws_sra_examples/solutions/inspector/inspector_org/lambda/src/inspector.py
+++ b/aws_sra_examples/solutions/inspector/inspector_org/lambda/src/inspector.py
@@ -131,6 +131,14 @@ def lookup_associated_accounts(inspector2_client: Inspector2Client, account_id: 
         response = inspector2_client.get_member(accountId=account_id)
     except inspector2_client.exceptions.ResourceNotFoundException:
         return False
+    except inspector2_client.exceptions.InternalServerException as e:
+        # Check if this is the specific error about account not being associated
+        if "is not an associated member" in str(e):
+            LOGGER.info(f"Account {account_id} is not an associated member yet")
+            return False
+        else:
+            LOGGER.error(f"Failed to get inspector members due to InternalServerException. {e}")
+            raise
     except Exception as e:
         LOGGER.error(f"Failed to get inspector members. {e}")
         raise


### PR DESCRIPTION
## Summary
This PR fixes issue #316 where Inspector account association checks would fail unexpectedly due to inconsistent AWS API behavior.

## Changes
- Add exception handling for InternalServerException in lookup_associated_accounts function
- AWS Inspector sometimes returns InternalServerException instead of ResourceNotFoundException
- Check error message for 'is not an associated member' to handle this case
- Ensures consistent behavior when checking account association status

## Testing
- [x] Code follows existing patterns and style
- [x] Error handling is comprehensive and logs appropriately
- [x] Fix addresses the root cause of issue #316

## Related Issues
Fixes #316