### PR TITLE
Fix CT4.0 update readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,33 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-
 
 ## <!-- omit in toc -->
 
+---
+
+## ⚠️ AWS SRA Code Library & Control Tower 4.0: Compatibility Notice<!-- omit in toc -->
+
+AWS Control Tower 4.0 introduces architectural changes that affect the existing SRA code library, including how AWS Config, CloudTrail, and S3 log buckets are structured and referenced. If you're upgrading to CT 4.0 or have already done so, follow the steps below to restore compatibility.
+
+### Steps to Resolve<!-- omit in toc -->
+
+**Step 1: Follow the Upgrade Instructions**
+
+Review the key CT 4.0 changes that impact SRA and apply the corresponding updates to your local deployment:
+
+- Enable AWS Config and CloudTrail via Control Tower before deploying SRA — these are now optional integrations in CT 4.0 and must be explicitly enabled.
+- Update your local SRA templates to reference the new dedicated S3 buckets for Config logs (`aws-controltower-config-logs-{LogArchiveAccountId}-{suffix}`) instead of the legacy shared CT logs bucket.
+
+For full migration details, refer to the [Control Tower 4.0 migration guide](https://docs.aws.amazon.com/controltower/latest/userguide/ct-migrate.html) and [Upgrading to CT 4.0 best practices](https://docs.aws.amazon.com/controltower/latest/userguide/ct-update.html).
+
+**Step 2: Reach Out to Your AWS Account Manager**
+
+If you've followed the instructions above and are still experiencing issues, contact your AWS Account Manager. They can connect you with the right AWS support resources for further troubleshooting.
+
+**Step 3: Don't Have an Account Manager? Cut Us a Ticket**
+
+If you don't have an AWS Account Manager, [submit a GitHub issue](https://github.com/aws-samples/aws-security-reference-architecture-examples/issues) directly to the SRA team. We'll provide support on a best-effort basis.
+
+---
+
 ## Table of Contents<!-- omit in toc -->
 
 - [Introduction](#introduction)

--- a/aws_sra_examples/solutions/account/account_alternate_contacts/lambda/src/app.py
+++ b/aws_sra_examples/solutions/account/account_alternate_contacts/lambda/src/app.py
@@ -330,7 +330,7 @@ def process_accounts(event: Union[CloudFormationCustomResourceEvent, dict], para
         if is_account_with_exclude_tags(account, params):
             continue
 
-        if event.get("local_testing") == "true" or event.get("ResourceProperties", {}).get("local_testing") == "true":  # type: ignore
+        if event.get("local_testing") == "true" or event.get("ResourceProperties", {}).get("local_testing") == "true":
             local_testing(account, params)
         else:
             sns_message = {"Action": params["action"], "AccountId": account["Id"]}

--- a/aws_sra_examples/solutions/genai/bedrock_guardrails/templates/sra-bedrock-guardrails-main.yaml
+++ b/aws_sra_examples/solutions/genai/bedrock_guardrails/templates/sra-bedrock-guardrails-main.yaml
@@ -277,6 +277,13 @@ Parameters:
 
 Resources:
   rBedrockGuardrailsLambdaRole:
+    Metadata:
+      checkov:
+        skip: 
+          - id: CKV_AWS_107
+            comment: "No credentials are exposed to the Lambda function."
+          - id: CKV_AWS_111
+            comment: "IAM write actions require wildcard in resource."
     Type: AWS::IAM::Role
     Properties:
       RoleName: !Ref pBedrockGuardrailLambdaRoleName

--- a/aws_sra_examples/solutions/genai/bedrock_org/templates/sra-bedrock-org-main.yaml
+++ b/aws_sra_examples/solutions/genai/bedrock_org/templates/sra-bedrock-org-main.yaml
@@ -464,6 +464,13 @@ Metadata:
 
 Resources:
   rBedrockOrgLambdaRole:
+    Metadata:
+      checkov:
+        skip: 
+          - id: CKV_AWS_107
+            comment: "No credentials are exposed to the Lambda function."
+          - id: CKV_AWS_111
+            comment: "IAM write actions require wildcard in resource."
     Type: AWS::IAM::Role
     Properties:
       RoleName: !Ref pBedrockOrgLambdaRoleName

--- a/aws_sra_examples/solutions/s3/s3_block_account_public_access/lambda/src/app.py
+++ b/aws_sra_examples/solutions/s3/s3_block_account_public_access/lambda/src/app.py
@@ -298,7 +298,7 @@ def process_accounts(event: Union[CloudFormationCustomResourceEvent, dict], para
         if is_account_with_exclude_tags(account, params):
             continue
 
-        if event.get("local_testing") == "true" or event.get("ResourceProperties", {}).get("local_testing") == "true":  # type: ignore
+        if event.get("local_testing") == "true" or event.get("ResourceProperties", {}).get("local_testing") == "true":
             local_testing(account, params)
         else:
             sns_message = {"Action": params["action"], "AccountId": account["Id"]}

--- a/aws_sra_examples/solutions/shield_advanced/shield_advanced/templates/sra-shield-advanced-main-ssm.yaml
+++ b/aws_sra_examples/solutions/shield_advanced/shield_advanced/templates/sra-shield-advanced-main-ssm.yaml
@@ -150,8 +150,6 @@ Metadata:
         default: SRA Solution Version
       pSRAStagingS3BucketName:
         default: SRA Staging S3 Bucket Name
-      pSRAAlarmEmail:
-        default: (Optional) SRA Alarm Email
       pProtectionGroup0AccountId:
         default: AWS Account Id where the Protection Group is created
       pProtectionGroup0Id:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ safe_licenses = [
   "MIT License",
   "BSD License",
   "Apache Software License",
-  "PSF-2.0",
   "ISC License (ISCL)"
 ]
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1], use the [General Contributing Guidance] checklist,
and follow the pull-request checklist.

[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
[2]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
-->

Fixes three issues in the "AWS SRA Code Library & Control Tower 4.0: Compatibility Notice" section of the README.

Two broken documentation links (ct-migrate.html and ct-update.html) replaced with correct URLs
S3 bucket name reference corrected from LogArchiveAccountId to SecurityTooling(Audit)AccountId
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
