### PR TITLE
fix(docs): Correct broken links and S3 bucket reference in CT 4.0 Com…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ AWS Control Tower 4.0 introduces architectural changes that affect the existing 
 Review the key CT 4.0 changes that impact SRA and apply the corresponding updates to your local deployment:
 
 - Enable AWS Config and CloudTrail via Control Tower before deploying SRA — these are now optional integrations in CT 4.0 and must be explicitly enabled.
-- Update your local SRA templates to reference the new dedicated S3 buckets for Config logs (`aws-controltower-config-logs-{LogArchiveAccountId}-{suffix}`) instead of the legacy shared CT logs bucket.
+- Update your local SRA templates to reference the new dedicated S3 buckets for Config logs (`aws-controltower-config-logs-{SecurityTooling(Audit)AccountId}-{suffix}`) instead of the legacy shared CT logs bucket.
 
-For full migration details, refer to the [Control Tower 4.0 migration guide](https://docs.aws.amazon.com/controltower/latest/userguide/ct-migrate.html) and [Upgrading to CT 4.0 best practices](https://docs.aws.amazon.com/controltower/latest/userguide/ct-update.html).
+For full migration details, refer to the [Control Tower 4.0 migration guide](https://docs.aws.amazon.com/controltower/latest/userguide/landing-zone-v4-migration-guide.html) and [Upgrading to CT 4.0 best practices](https://docs.aws.amazon.com/controltower/latest/userguide/lz-update-best-practices.html).
 
 **Step 2: Reach Out to Your AWS Account Manager**
 


### PR DESCRIPTION
…patibility Notice

- Fix Control Tower 4.0 migration guide link (ct-migrate.html -> landing-zone-v4-migration-guide.html)
- Fix Upgrading to CT 4.0 best practices link (ct-update.html -> lz-update-best-practices.html)
- Fix S3 bucket name reference from LogArchiveAccountId to SecurityTooling(Audit)AccountId

<!-- markdownlint-disable MD041 -->
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1], use the [General Contributing Guidance] checklist,
and follow the pull-request checklist.

[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
[2]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
-->

Fixed logarchive to security tooling
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
