### PR TITLE
fix: allow extra safe licenses in pylic check to unblock CI

### DIFF
--- a/.github/workflows/pylic.yml
+++ b/.github/workflows/pylic.yml
@@ -59,4 +59,4 @@ jobs:
       - name: pylic check
         run: |
           poetry run pip install pylic
-          poetry run pylic check
+          poetry run pylic check --allow-extra-safe-licenses


### PR DESCRIPTION
The pylic workflow fails on main with:

  Safe licenses listed which are not used by any installed package:
    BSD-3-Clause

This is not a license violation. No installed package carries a disallowed license; pylic objects that BSD-3-Clause is listed in [tool.pylic] safe_licenses while no installed package currently uses it.

Two factors combine to trigger it. The workflow runs a bare `pip install pylic` with no version constraint, so it bypasses the pylic = "^3.4.0" pin in pyproject.toml and resolves pylic 5.x, which turned unused safe_licenses entries into a hard failure. And the job installs `--only main`, so the small dependency set leaves BSD-3-Clause unmatched.

Pass --allow-extra-safe-licenses, the flag pylic 5 provides for exactly this case. The entry stays in the allowlist and is reported as informational instead of fatal, so the check keeps failing on genuinely unsafe licenses while no longer failing on an unused allowlist entry.

Verified locally against a venv reproducing the CI environment (main-only dependencies, pylic 5.0.1): reproduces the failure (exit 1) before the change and passes with "All licenses ok" (exit 0) after, with BSD-3-Clause retained.

Note that pinning to pylic <4 was considered and rejected: pylic 3.6.1 fails more broadly in this environment, additionally reporting MIT as unused and flagging six packages (including setuptools and urllib3) as unsafe.

<!-- markdownlint-disable MD041 -->
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1], use the [General Contributing Guidance] checklist,
and follow the pull-request checklist.

[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
[2]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
